### PR TITLE
Canonical serialization format for RangeProof

### DIFF
--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -192,25 +192,23 @@ impl InnerProductProof {
         let inv_s = s.iter().rev();
 
         let h_times_b_div_s = Hprime_factors
-             .into_iter()
-             .zip(inv_s)
-             .map(|(h_i, s_i_inv)| (self.b * s_i_inv) * h_i.borrow());
+            .into_iter()
+            .zip(inv_s)
+            .map(|(h_i, s_i_inv)| (self.b * s_i_inv) * h_i.borrow());
 
         let neg_u_sq = u_sq.iter().map(|ui| -ui);
         let neg_u_inv_sq = u_inv_sq.iter().map(|ui| -ui);
 
-        let Ls = self.L_vec
+        let Ls = self
+            .L_vec
             .iter()
-            .map(|p| {
-                p.decompress().ok_or("InnerProductProof L point is invalid")
-            })
+            .map(|p| p.decompress().ok_or("InnerProductProof L point is invalid"))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let Rs = self.R_vec
+        let Rs = self
+            .R_vec
             .iter()
-            .map(|p| {
-                p.decompress().ok_or("InnerProductProof R point is invalid")
-            })
+            .map(|p| p.decompress().ok_or("InnerProductProof R point is invalid"))
             .collect::<Result<Vec<_>, _>>()?;
 
         let expect_P = RistrettoPoint::vartime_multiscalar_mul(
@@ -267,9 +265,7 @@ impl InnerProductProof {
         }
         let num_elements = b / 32;
         if num_elements < 2 {
-            return Err(
-                "InnerProductProof must contain at least two 32-byte elements",
-            );
+            return Err("InnerProductProof must contain at least two 32-byte elements");
         }
         if (num_elements - 2) % 2 != 0 {
             return Err("InnerProductProof must contain even number of points");

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -231,8 +231,11 @@ impl InnerProductProof {
         }
     }
 
-    /// Returns the size in bytes required to serialize the inner product proof.
-    /// For `n` multiplications the proof size is \\(32 \cdot (2\lg n+2)\\) bytes.
+    /// Returns the size in bytes required to serialize the inner
+    /// product proof.
+    ///
+    /// For vectors of length `n` the proof size is
+    /// \\(32 \cdot (2\lg n+2)\\) bytes.
     pub fn serialized_size(&self) -> usize {
         (self.L_vec.len() * 2 + 2) * 32
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! Note that docs will only build on nightly Rust until
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
 
+extern crate core;
 extern crate byteorder;
 extern crate curve25519_dalek;
 extern crate rand;
@@ -17,6 +18,7 @@ extern crate tiny_keccak;
 
 #[macro_use]
 extern crate serde_derive;
+extern crate serde;
 
 #[cfg(test)]
 extern crate test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@
 //! Note that docs will only build on nightly Rust until
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
 
-extern crate core;
 extern crate byteorder;
+extern crate core;
 extern crate curve25519_dalek;
 extern crate rand;
 extern crate sha2;

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -232,10 +232,10 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
         );
 
         Ok(RangeProof {
-            A: self.A,
-            S: self.S,
-            T_1: self.T_1,
-            T_2: self.T_2,
+            A: self.A.compress(),
+            S: self.S.compress(),
+            T_1: self.T_1.compress(),
+            T_2: self.T_2.compress(),
             t_x,
             t_x_blinding,
             e_blinding,

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -80,7 +80,8 @@ impl ProofShare {
         }
 
         let g = self.l_vec.iter().map(|l_i| minus_z - l_i);
-        let h = self.r_vec
+        let h = self
+            .r_vec
             .iter()
             .zip(util::exp_iter(Scalar::from_u64(2)))
             .zip(util::exp_iter(y_inv))

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -14,8 +14,8 @@ use inner_product_proof::InnerProductProof;
 use proof_transcript::ProofTranscript;
 use util;
 
-use serde::{self, Serialize, Deserialize, Serializer, Deserializer};
 use serde::de::Visitor;
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 
 // Modules for MPC protocol
 
@@ -197,13 +197,15 @@ impl RangeProof {
         let value_commitment_scalars = util::exp_iter(z).take(m).map(|z_exp| c * zz * z_exp);
         let basepoint_scalar = w * (self.t_x - a * b) + c * (delta(n, m, &y, &z) - self.t_x);
 
-        let Ls = self.ipp_proof
+        let Ls = self
+            .ipp_proof
             .L_vec
             .iter()
             .map(|p| p.decompress().ok_or("RangeProof's L point is invalid"))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let Rs = self.ipp_proof
+        let Rs = self
+            .ipp_proof
             .R_vec
             .iter()
             .map(|p| p.decompress().ok_or("RangeProof's R point is invalid"))
@@ -346,7 +348,6 @@ impl<'de> Deserialize<'de> for RangeProof {
         deserializer.deserialize_bytes(RangeProofVisitor)
     }
 }
-
 
 /// Compute
 /// \\[

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -209,6 +209,11 @@ impl RangeProof {
             .map(|p| p.decompress().ok_or("RangeProof's R point is invalid"))
             .collect::<Result<Vec<_>, _>>()?;
 
+        let A = self.A.decompress().ok_or("RangeProof A is invalid")?;
+        let S = self.S.decompress().ok_or("RangeProof S is invalid")?;
+        let T_1 = self.T_1.decompress().ok_or("RangeProof T_1 is invalid")?;
+        let T_2 = self.T_2.decompress().ok_or("RangeProof T_2 is invalid")?;
+
         let mega_check = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(Scalar::one())
                 .chain(iter::once(x))
@@ -221,18 +226,11 @@ impl RangeProof {
                 .chain(h)
                 .chain(x_sq.iter().cloned())
                 .chain(x_inv_sq.iter().cloned()),
-            iter::once(&self.A.decompress().ok_or(
-                "RangeProof.A is invalid Ristretto point",
-            )?).chain(iter::once(&self.S.decompress().ok_or(
-                "RangeProof.S is invalid Ristretto point",
-            )?))
+            iter::once(&A)
+                .chain(iter::once(&S))
                 .chain(value_commitments.iter())
-                .chain(iter::once(&self.T_1.decompress().ok_or(
-                    "RangeProof.T_1 is invalid Ristretto point",
-                )?))
-                .chain(iter::once(&self.T_2.decompress().ok_or(
-                    "RangeProof.T_2 is invalid Ristretto point",
-                )?))
+                .chain(iter::once(&T_1))
+                .chain(iter::once(&T_2))
                 .chain(iter::once(&gens.pedersen_generators.B_blinding))
                 .chain(iter::once(&gens.pedersen_generators.B))
                 .chain(gens.G.iter())

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -285,22 +285,31 @@ impl RangeProof {
             return Err("RangeProof must contain at least seven 32-byte elements");
         }
 
-        use util::{read_ristretto, decode_scalar};
+        use util::read32;
+
+        let A = CompressedRistretto(read32(&slice[0 * 32..]));
+        let S = CompressedRistretto(read32(&slice[1 * 32..]));
+        let T_1 = CompressedRistretto(read32(&slice[2 * 32..]));
+        let T_2 = CompressedRistretto(read32(&slice[3 * 32..]));
+
+        let t_x = Scalar::from_canonical_bytes(read32(&slice[4 * 32..]))
+            .ok_or("RangeProof.t_x is not a canonical scalar")?;
+        let t_x_blinding = Scalar::from_canonical_bytes(read32(&slice[5 * 32..]))
+            .ok_or("RangeProof.t_x_blinding is not a canonical scalar")?;
+        let e_blinding = Scalar::from_canonical_bytes(read32(&slice[6 * 32..]))
+            .ok_or("RangeProof.e_blinding is not a canonical scalar")?;
+
+        let ipp_proof = InnerProductProof::from_bytes(&slice[7 * 32..])?;
+
         Ok(RangeProof {
-            A: read_ristretto(&slice[0 * 32..]),
-            S: read_ristretto(&slice[1 * 32..]),
-            T_1: read_ristretto(&slice[2 * 32..]),
-            T_2: read_ristretto(&slice[3 * 32..]),
-            t_x: decode_scalar(&slice[4 * 32..][..32]).ok_or(
-                "RangeProof.t_x is not a canonical scalar",
-            )?,
-            t_x_blinding: decode_scalar(&slice[5 * 32..][..32]).ok_or(
-                "RangeProof.t_x_blinding is not a canonical scalar",
-            )?,
-            e_blinding: decode_scalar(&slice[6 * 32..][..32]).ok_or(
-                "RangeProof.e_blinding is not a canonical scalar",
-            )?,
-            ipp_proof: InnerProductProof::from_bytes(&slice[7 * 32..])?,
+            A,
+            S,
+            T_1,
+            T_2,
+            t_x,
+            t_x_blinding,
+            e_blinding,
+            ipp_proof,
         })
     }
 }

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -158,11 +158,13 @@ impl<'a> PartyAwaitingValueChallenge<'a> {
         // Generate x by committing to T_1, T_2 (line 49-54)
         let t_1_blinding = Scalar::random(rng);
         let t_2_blinding = Scalar::random(rng);
-        let T_1 = self.generators
+        let T_1 = self
+            .generators
             .share(self.j)
             .pedersen_generators
             .commit(t_poly.1, t_1_blinding);
-        let T_2 = self.generators
+        let T_2 = self
+            .generators
             .share(self.j)
             .pedersen_generators
             .commit(t_poly.2, t_2_blinding);

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@
 #![allow(non_snake_case)]
 
 use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::ristretto::CompressedRistretto;
 use inner_product_proof::inner_product;
 
 /// Represents a degree-1 vector polynomial \\(\mathbf{a} + \mathbf{b} \cdot x\\).
@@ -125,6 +126,25 @@ pub fn sum_of_powers(x: &Scalar, n: usize) -> Scalar {
 // takes the sum of all of the powers of x, up to n
 fn sum_of_powers_slow(x: &Scalar, n: usize) -> Scalar {
     exp_iter(*x).take(n).sum()
+}
+
+/// Reads a ristretto point from a 32-byte compressed form, slicing first 32 bytes.
+/// WARNING: caller must provide a slice of 32+ bytes.
+pub fn read_ristretto(data: &[u8]) -> CompressedRistretto {
+    let mut buf32 = [0u8; 32];
+    buf32[..].copy_from_slice(&data[..32]);
+    CompressedRistretto(buf32)
+}
+
+/// Decodes a canonical scalar from a 32-byte compressed form.
+pub fn decode_scalar(data: &[u8]) -> Option<Scalar> {
+    if data.len() != 32 {
+        // we don't need an error code as caller would have checked the length already
+        return None;
+    }
+    let mut buf32 = [0u8; 32];
+    buf32[..].copy_from_slice(data);
+    Scalar::from_canonical_bytes(buf32)
 }
 
 #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,6 @@
 #![allow(non_snake_case)]
 
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::ristretto::CompressedRistretto;
 use inner_product_proof::inner_product;
 
 /// Represents a degree-1 vector polynomial \\(\mathbf{a} + \mathbf{b} \cdot x\\).
@@ -128,23 +127,11 @@ fn sum_of_powers_slow(x: &Scalar, n: usize) -> Scalar {
     exp_iter(*x).take(n).sum()
 }
 
-/// Reads a ristretto point from a 32-byte compressed form, slicing first 32 bytes.
-/// WARNING: caller must provide a slice of 32+ bytes.
-pub fn read_ristretto(data: &[u8]) -> CompressedRistretto {
+/// Given `data` with `len >= 32`, return the first 32 bytes.
+pub fn read32(data: &[u8]) -> [u8; 32] {
     let mut buf32 = [0u8; 32];
     buf32[..].copy_from_slice(&data[..32]);
-    CompressedRistretto(buf32)
-}
-
-/// Decodes a canonical scalar from a 32-byte compressed form.
-pub fn decode_scalar(data: &[u8]) -> Option<Scalar> {
-    if data.len() != 32 {
-        // we don't need an error code as caller would have checked the length already
-        return None;
-    }
-    let mut buf32 = [0u8; 32];
-    buf32[..].copy_from_slice(data);
-    Scalar::from_canonical_bytes(buf32)
+    buf32
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This adds a canonical encoding algorithm for a RangeProof in form of `to_bytes`/`from_bytes` API. Serde trait is implemented in terms of these. 

The layout of an `2^n`-bit range proof is defined as:
* 4 compressed Ristretto points `A, S, T_1, T_2`,
* 3 scalars `t_x, t_x_blinding, e_blinding`,
* `2*n` pairs of compressed Ristretto points `L_0, R_0, ..., L_{n-1}, R_{n-1}`,
* two scalars `a` and `b`.

Total size: `32*(9+2*n)` bytes. 

64-bit range proofs are encoded in 672 bytes, 32-bit range proofs are encoded in 608 bytes.

Bonus: the compressed data is cached and reused in verification, so we do not incur unnecessary cost of compressing points that we decompressed just prior to verification.

PS. Serde is intentionally not implemented for IPP as we don't seem to be exposing it directly to users. If we ever need to, we can add ser/de trait implementation like we do with RangeProof.