### PR TITLE
R1CS circuit frontend

### DIFF
--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -12,8 +12,8 @@ use inner_product_proof::{inner_product, InnerProductProof};
 use proof_transcript::ProofTranscript;
 use util;
 
-// Note: we can swap out this circuit representation later, when we have R1CS support,
-// since for large circuits we don't want to keep all the matrices in memory.
+pub mod r1cs;
+
 #[derive(Clone, Debug)]
 pub struct Circuit {
     n: usize,
@@ -388,7 +388,7 @@ pub fn matrix_flatten(
 
     for row in 0..W.len() {
         if W[row].len() != output_dim {
-            return Err("matrix size doesn't match specified parameters in matrix_flatten");
+            return Err("Matrix size doesn't match specified parameters in matrix_flatten");
         }
         for col in 0..output_dim {
             result[col] += exp_z * W[row][col];

--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -48,6 +48,7 @@ pub struct ProverInput {
     a_L: Vec<Scalar>,
     a_R: Vec<Scalar>,
     a_O: Vec<Scalar>,
+    v_blinding: Vec<Scalar>,
 }
 
 pub struct VerifierInput {

--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -147,11 +147,11 @@ impl CircuitProof {
 
         let mut l_poly = util::VecPoly3::zero(circuit.n);
         let mut r_poly = util::VecPoly3::zero(circuit.n);
-        
+
         let z_zQ_WL: Vec<Scalar> = matrix_flatten(&circuit.W_L, z, circuit.n)?;
         let z_zQ_WR: Vec<Scalar> = matrix_flatten(&circuit.W_R, z, circuit.n)?;
         let z_zQ_WO: Vec<Scalar> = matrix_flatten(&circuit.W_O, z, circuit.n)?;
-    
+
         let mut exp_y = Scalar::one(); // y^n starting at n=0
         let mut exp_y_inv = Scalar::one(); // y^-n starting at n=0
         let y_inv = y.invert();
@@ -330,10 +330,8 @@ impl CircuitProof {
 
         // W_L_point = <h * y^-n , z * z^Q * W_L>, line 81
         let W_L_flatten: Vec<Scalar> = matrix_flatten(&circuit.W_L, z, circuit.n)?;
-        let W_L_point = RistrettoPoint::vartime_multiscalar_mul(
-            W_L_flatten.clone(),
-            H_prime.iter()
-        );
+        let W_L_point =
+            RistrettoPoint::vartime_multiscalar_mul(W_L_flatten.clone(), H_prime.iter());
 
         // W_R_point = <g , y^-n * z * z^Q * W_R>, line 82
         let W_R_flatten: Vec<Scalar> = matrix_flatten(&circuit.W_R, z, circuit.n)?;
@@ -347,10 +345,7 @@ impl CircuitProof {
 
         // W_O_point = <h * y^-n , z * z^Q * W_O>, line 83
         let W_O_flatten: Vec<Scalar> = matrix_flatten(&circuit.W_O, z, circuit.n)?;
-        let W_O_point = RistrettoPoint::vartime_multiscalar_mul(
-            W_O_flatten,
-            H_prime.iter()
-        );
+        let W_O_point = RistrettoPoint::vartime_multiscalar_mul(W_O_flatten, H_prime.iter());
 
         // Get IPP variables
         let (x_sq, x_inv_sq, s) = self.ipp_proof.verification_scalars(transcript);
@@ -508,13 +503,7 @@ mod tests {
 
         let mut verify_transcript = ProofTranscript::new(b"CircuitProofTest");
 
-        circuit_proof.verify(
-            &generators,
-            &mut verify_transcript,
-            &mut rng,
-            &circuit,
-            V,
-        )
+        circuit_proof.verify(&generators, &mut verify_transcript, &mut rng, &circuit, V)
     }
 
     fn blinding_helper(v: &Vec<Scalar>) -> (Vec<RistrettoPoint>, Vec<Scalar>) {

--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -451,7 +451,6 @@ mod tests {
         };
 
         let circuit_proof = CircuitProof::prove(
-<<<<<<< HEAD
             &generators,
             &mut proof_transcript,
             &mut rng,

--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -48,7 +48,7 @@ pub struct CircuitInput {
     a_L: Vec<Scalar>,
     a_R: Vec<Scalar>,
     a_O: Vec<Scalar>,
-    v_blinding: Vec<Scalar>, // should this also contain V (commitment?) - TBD
+    // v_blinding: Vec<Scalar>, // should this also contain V (commitment?) - TBD
 }
 
 #[derive(Clone, Debug)]

--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -13,6 +13,7 @@ use proof_transcript::ProofTranscript;
 use util;
 
 pub mod r1cs;
+// TODO: move circuit proof code into another file and import, so folder is more balanced.
 
 #[derive(Clone, Debug)]
 pub struct Circuit {

--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -42,6 +42,14 @@ impl Circuit {
     }
 }
 
+// TODO: actually use this in circuit generation
+pub struct CircuitInput {
+    a_L: Vec<Scalar>,
+    a_R: Vec<Scalar>,
+    a_O: Vec<Scalar>,
+    v_blinding: Vec<Scalar>, // should this also contain V (commitment?) - TBD
+}
+
 #[derive(Clone, Debug)]
 pub struct CircuitProof {
     pub A_I: RistrettoPoint,

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -1,0 +1,17 @@
+use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::ristretto::RistrettoPoint;
+
+/// Represents a variable in our constraint system.
+#[derive(Copy, Clone, Debug)]
+pub struct Variable(Index);
+
+/// Represents the index of either a public or private variable.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum Index {
+    Public(usize),
+    Private(usize)
+}
+
+/// This represents a linear combination of some variables, with scalar coefficients.
+#[derive(Clone)]
+pub struct LinearCombination(Vec<Variable, Scalar>);

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -1,17 +1,108 @@
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::ristretto::RistrettoPoint;
 
-/// Represents a variable in our constraint system.
-#[derive(Copy, Clone, Debug)]
-pub struct Variable(Index);
+use circuit_proof::{Circuit, CircuitInput};
 
-/// Represents the index of either a public or private variable.
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub enum Index {
-    Public(usize),
-    Private(usize)
+// This is a stripped-down version of the Bellman r1cs representation, for the purposes of
+// learning / understanding. The goal is to write this as a BulletproofsConstraintSystem that 
+// implements the Bellman ConstraintSystem trait, so we can use that code/logic.
+// (That would require the bellman code to be decoupled from the underlying pairings.)
+
+/// Represents a variable in our constraint system, where the value represents the index.
+pub struct Variable(usize);
+
+/// Represents a linear combination of some variables multiplied with their scalar coefficients, 
+/// plus a scalar. E.g. LC = variable[0]*scalar[0] + variable[1]*scalar[1] + scalar
+pub struct LinearCombination {
+	variables: Vec<(Variable, Scalar)>,
+	constant: Scalar, 
 }
 
-/// This represents a linear combination of some variables, with scalar coefficients.
-#[derive(Clone)]
-pub struct LinearCombination(Vec<Variable, Scalar>);
+impl LinearCombination {
+	// TODO: make constructor with iterators
+	// see FromIterator trait - [(a1, v1), (a2, v2)].iter().collect() (pass in the iterator, collect to get LC)
+	pub fn construct(variables: Vec<(Variable, Scalar)>, constant: Scalar) -> Self {
+		LinearCombination {
+			variables,
+			constant,
+		}
+	}
+}
+
+/// Represents a vector of groups of 3 linear combinations, where a * b = c
+pub struct ConstraintSystem {
+	// a[i] * b[i] = c[i] for all i
+	a: Vec<LinearCombination>,
+	b: Vec<LinearCombination>,
+	c: Vec<LinearCombination>,
+
+	// Assignments of variables
+	var_assignment: Vec<Scalar>,
+}
+// (?) We also need to keep track of the evals of a, b, c (to know what values to assign to variables?)
+
+impl ConstraintSystem {
+	// TODO: make it so you have to request variables from the constraint system,
+	// so it does variable allocation and assignment at the same time
+	pub fn alloc_variable(&self, val: Scalar) -> Variable {
+		unimplemented!();
+	}
+
+	pub fn create_proof_input(&self) -> (Circuit, CircuitInput) {
+		unimplemented!();
+	}
+}
+
+#[cfg(test)]
+	mod tests {
+    use super::*; 
+
+	#[test]
+	// trivial case using constant multiplication
+    fn mul_circuit_constants() {
+    	let lc_a = LinearCombination::construct(vec![], Scalar::from_u64(3));
+    	let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(4));
+    	let lc_c = LinearCombination::construct(vec![], Scalar::from_u64(12));
+    	
+    	let cs = ConstraintSystem {
+    		a: vec![lc_a], 
+    		b: vec![lc_b], 
+    		c: vec![lc_c],
+    		var_assignment: vec![],
+    	};
+
+    	let (circuit, circuit_input) = cs.create_proof_input();
+    	assert_eq!(circuit.q, 3);
+    }
+
+    #[test]
+    // multiplication circuit where a, b, c are all (private?) variables
+    fn mul_circuit_variables() {
+    	// TODO: use alloc_variable to create the variables instead
+    	let var_a = Variable(0);
+    	let var_b = Variable(1);
+    	let var_c = Variable(2);
+
+    	let lc_a = LinearCombination {
+    		variables: vec![(var_a, Scalar::one())],
+    		constant: Scalar::zero(),
+    	};
+    	let lc_b = LinearCombination {
+    		variables: vec![(var_b, Scalar::one())],
+    		constant: Scalar::zero(),
+    	};
+    	let lc_c = LinearCombination {
+    		variables: vec![(var_c, Scalar::one())],
+    		constant: Scalar::zero(),
+    	};
+
+    	let cs = ConstraintSystem {
+    		a: vec![lc_a], 
+    		b: vec![lc_b], 
+    		c: vec![lc_c],
+    		var_assignment: vec![Scalar::from_u64(3), Scalar::from_u64(4), Scalar::from_u64(12)],
+    	};
+
+    	let proof_input = cs.create_proof_input();
+    }
+}

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -2,7 +2,7 @@ use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use std::iter::FromIterator;
 
-use circuit_proof::{Circuit, CircuitInput};
+use circuit_proof::{Circuit, ProverInput, VerifierInput};
 
 // This is a stripped-down version of the Bellman r1cs representation, for the purposes of
 // learning / understanding. The goal is to write this as a BulletproofsConstraintSystem that 
@@ -105,7 +105,7 @@ impl ConstraintSystem {
 		Ok(())
 	}
 
-	pub fn create_proof_input(&self) -> (Circuit, CircuitInput) {
+	pub fn create_proof_input(&self) -> (Circuit, ProverInput) {
 		// naive conversion that doesn't do any multiplication elimination
 		let n = self.a.len();
 		let m = self.var_assignment.len();
@@ -143,16 +143,14 @@ impl ConstraintSystem {
 			c[i] = lc.get_constant();
 		};
 
-		let mut rng = OsRng::new().unwrap();
-
 		let circuit = Circuit {
 			n, m, q, c,
 			W_L, W_R, W_O, W_V
 		};
-		let circuit_input = CircuitInput {
+		let prover_input = ProverInput {
 			a_L, a_R, a_O
 		};
-		(circuit, circuit_input)
+		(circuit, prover_input)
 	}
 }
 

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -1,14 +1,14 @@
 use rand::{CryptoRng, Rng};
 
-use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::ristretto::RistrettoPoint;
-use std::iter::FromIterator;
+use curve25519_dalek::scalar::Scalar;
 use generators::PedersenGenerators;
+use std::iter::FromIterator;
 
 use circuit_proof::{Circuit, ProverInput, VerifierInput};
 
 // This is a stripped-down version of the Bellman r1cs representation, for the purposes of
-// learning / understanding. The goal is to write this as a BulletproofsConstraintSystem that 
+// learning / understanding. The goal is to write this as a BulletproofsConstraintSystem that
 // implements the Bellman ConstraintSystem trait, so we can use that code/logic.
 // (That would require the bellman code to be decoupled from the underlying pairings.)
 
@@ -17,138 +17,158 @@ use circuit_proof::{Circuit, ProverInput, VerifierInput};
 pub struct Variable(usize);
 
 impl Variable {
-	pub fn get_index(&self) -> usize {
-		self.0
-	}
+    pub fn get_index(&self) -> usize {
+        self.0
+    }
 }
 
-/// Represents a linear combination of some variables multiplied with their scalar coefficients, 
+/// Represents a linear combination of some variables multiplied with their scalar coefficients,
 /// plus a scalar. E.g. LC = variable[0]*scalar[0] + variable[1]*scalar[1] + scalar
 pub struct LinearCombination {
-	variables: Vec<(Variable, Scalar)>,
-	constant: Scalar, 
+    variables: Vec<(Variable, Scalar)>,
+    constant: Scalar,
 }
 
 impl LinearCombination {
-	// TODO: make constructor with iterators
-	// see FromIterator trait - [(a1, v1), (a2, v2)].iter().collect() (pass in the iterator, collect to get LC)
-	pub fn construct(variables: Vec<(Variable, Scalar)>, constant: Scalar) -> Self {
-		LinearCombination {
-			variables,
-			constant,
-		}
-	}
+    // TODO: make constructor with iterators
+    // see FromIterator trait - [(a1, v1), (a2, v2)].iter().collect() (pass in the iterator, collect to get LC)
+    pub fn construct(variables: Vec<(Variable, Scalar)>, constant: Scalar) -> Self {
+        LinearCombination {
+            variables,
+            constant,
+        }
+    }
 
-	// Used to check that variables in the linear combination are valid
-	pub fn check_variables(&self, var_count: usize) -> Result<(), &'static str> {
-		for (var, _) in &self.variables {
-			let index = var.get_index();
-			if index > var_count - 1 {
-				return Err("Invalid variable index");
-			}
-		}
-		Ok(())
-	}
+    // Used to check that variables in the linear combination are valid
+    pub fn check_variables(&self, var_count: usize) -> Result<(), &'static str> {
+        for (var, _) in &self.variables {
+            let index = var.get_index();
+            if index > var_count - 1 {
+                return Err("Invalid variable index");
+            }
+        }
+        Ok(())
+    }
 
-	pub fn get_variables(&self) -> Vec<(Variable, Scalar)> {
-		self.variables.clone()
-	}
+    pub fn get_variables(&self) -> Vec<(Variable, Scalar)> {
+        self.variables.clone()
+    }
 
-	pub fn get_constant(&self) -> Scalar {
-		self.constant.clone()
-	}
+    pub fn get_constant(&self) -> Scalar {
+        self.constant.clone()
+    }
 
-	// evaluate the linear combination, given the variable values in var_assignment
-	pub fn eval(&self, var_assignment: &Vec<Scalar>) -> Scalar {
-		let sum_vars: Scalar = self.variables.iter()
-					.map(|(var, scalar)|
-						scalar * var_assignment[var.get_index()]
-					).sum();
-		sum_vars + self.constant
-	}
+    // evaluate the linear combination, given the variable values in var_assignment
+    pub fn eval(&self, var_assignment: &Vec<Scalar>) -> Scalar {
+        let sum_vars: Scalar = self
+            .variables
+            .iter()
+            .map(|(var, scalar)| scalar * var_assignment[var.get_index()])
+            .sum();
+        sum_vars + self.constant
+    }
 }
 
 /// Represents a vector of groups of 3 linear combinations, where a * b = c
 pub struct ConstraintSystem {
-	// a[i] * b[i] = c[i] for all i
-	a: Vec<LinearCombination>,
-	b: Vec<LinearCombination>,
-	c: Vec<LinearCombination>,
+    // a[i] * b[i] = c[i] for all i
+    a: Vec<LinearCombination>,
+    b: Vec<LinearCombination>,
+    c: Vec<LinearCombination>,
 
-	// Assignments of variables
-	var_assignment: Vec<Scalar>,
+    // Assignments of variables
+    var_assignment: Vec<Scalar>,
 }
 
 impl ConstraintSystem {
-	pub fn new() -> Self {
-		ConstraintSystem {
-			a: vec![],
-			b: vec![],
-			c: vec![],
-			var_assignment: vec![],
-		}
-	}
-	// Allocate a variable and do value assignment at the same time
-	pub fn alloc_variable(&mut self, val: Scalar) -> Variable {
-		self.var_assignment.push(val);
-		Variable(self.var_assignment.len()-1)
-	}
+    pub fn new() -> Self {
+        ConstraintSystem {
+            a: vec![],
+            b: vec![],
+            c: vec![],
+            var_assignment: vec![],
+        }
+    }
+    // Allocate a variable and do value assignment at the same time
+    pub fn alloc_variable(&mut self, val: Scalar) -> Variable {
+        self.var_assignment.push(val);
+        Variable(self.var_assignment.len() - 1)
+    }
 
-	// Push one set of linear constraints (a, b, c) to the constraint system.
-	// Pushing a, b, c together prevents mismatched constraints.
-	pub fn push_lc(&mut self, lc_a: LinearCombination, lc_b: LinearCombination, lc_c: LinearCombination)
-	-> Result<(), &'static str> {
-		let num_vars = self.var_assignment.len();
-		lc_a.check_variables(num_vars)?;
-		lc_b.check_variables(num_vars)?;
-		lc_c.check_variables(num_vars)?;
-		self.a.push(lc_a);
-		self.b.push(lc_b);
-		self.c.push(lc_c);
-		Ok(())
-	}
+    // Push one set of linear constraints (a, b, c) to the constraint system.
+    // Pushing a, b, c together prevents mismatched constraints.
+    pub fn push_lc(
+        &mut self,
+        lc_a: LinearCombination,
+        lc_b: LinearCombination,
+        lc_c: LinearCombination,
+    ) -> Result<(), &'static str> {
+        let num_vars = self.var_assignment.len();
+        lc_a.check_variables(num_vars)?;
+        lc_b.check_variables(num_vars)?;
+        lc_c.check_variables(num_vars)?;
+        self.a.push(lc_a);
+        self.b.push(lc_b);
+        self.c.push(lc_c);
+        Ok(())
+    }
 
-	pub fn create_proof_input<R: Rng + CryptoRng>(
-		&self,
-		pedersen_generators: &PedersenGenerators,
-		rng: &mut R,
-	) -> (Circuit, ProverInput, VerifierInput) {
-		// naive conversion that doesn't do any multiplication elimination
-		let n = self.a.len();
-		let m = self.var_assignment.len();
-		let q = self.a.len() * 3;
+    pub fn create_proof_input<R: Rng + CryptoRng>(
+        &self,
+        pedersen_generators: &PedersenGenerators,
+        rng: &mut R,
+    ) -> (Circuit, ProverInput, VerifierInput) {
+        // naive conversion that doesn't do any multiplication elimination
+        let n = self.a.len();
+        let m = self.var_assignment.len();
+        let q = self.a.len() * 3;
 
-		// eval a, b, c and assign results to a_L, a_R, a_O respectively
-		let a_L: Vec<Scalar> = 
-			self.a.iter().map(|lc| lc.eval(&self.var_assignment)).collect();
-		let a_R: Vec<Scalar> = 
-			self.b.iter().map(|lc| lc.eval(&self.var_assignment)).collect();
-		let a_O: Vec<Scalar> = 
-			self.c.iter().map(|lc| lc.eval(&self.var_assignment)).collect();
+        // eval a, b, c and assign results to a_L, a_R, a_O respectively
+        let a_L: Vec<Scalar> = self
+            .a
+            .iter()
+            .map(|lc| lc.eval(&self.var_assignment))
+            .collect();
+        let a_R: Vec<Scalar> = self
+            .b
+            .iter()
+            .map(|lc| lc.eval(&self.var_assignment))
+            .collect();
+        let a_O: Vec<Scalar> = self
+            .c
+            .iter()
+            .map(|lc| lc.eval(&self.var_assignment))
+            .collect();
 
-		// Linear constraints are ordered as follows:
-		// a[0], a[1], ... b[0], b[1], ... c[0], c[1], ...
-		// s.t. W_L || W_R || W_O || c || W_V matrix is in reduced row echelon form
-		let zer = Scalar::zero();
-		let one = Scalar::one();
-		let mut W_L = vec![vec![zer; n]; q]; // qxn matrix which corresponds to a.
-		let mut W_R = vec![vec![zer; n]; q]; // qxn matrix which corresponds to b.
-		let mut W_O = vec![vec![zer; n]; q]; // qxn matrix which corresponds to c.
-		for i in 0..n {
-			W_L[i][i] = one;
-			W_R[i + n][i] = one;
-			W_O[i + 2*n][i] = one;
-		}
+        // Linear constraints are ordered as follows:
+        // a[0], a[1], ... b[0], b[1], ... c[0], c[1], ...
+        // s.t. W_L || W_R || W_O || c || W_V matrix is in reduced row echelon form
+        let zer = Scalar::zero();
+        let one = Scalar::one();
+        let mut W_L = vec![vec![zer; n]; q]; // qxn matrix which corresponds to a.
+        let mut W_R = vec![vec![zer; n]; q]; // qxn matrix which corresponds to b.
+        let mut W_O = vec![vec![zer; n]; q]; // qxn matrix which corresponds to c.
+        for i in 0..n {
+            W_L[i][i] = one;
+            W_R[i + n][i] = one;
+            W_O[i + 2 * n][i] = one;
+        }
 
-		// TODO: create / append to c on the fly instead
-		let mut c = vec![zer; q]; // length q vector of constants.
-		let mut W_V = vec![vec![zer; m]; q]; // qxm matrix of commitments.
-		for (i, lc) in self.a.iter().chain(self.b.iter()).chain(self.c.iter()).enumerate() {
-			for (var, scalar) in lc.get_variables() {
-				W_V[i][var.get_index()] = scalar;
-			}
-			c[i] = lc.get_constant();
-		};
+        // TODO: create / append to c on the fly instead
+        let mut c = vec![zer; q]; // length q vector of constants.
+        let mut W_V = vec![vec![zer; m]; q]; // qxm matrix of commitments.
+        for (i, lc) in self
+            .a
+            .iter()
+            .chain(self.b.iter())
+            .chain(self.c.iter())
+            .enumerate()
+        {
+            for (var, scalar) in lc.get_variables() {
+                W_V[i][var.get_index()] = scalar;
+            }
+            c[i] = lc.get_constant();
+        }
 
         let v_blinding: Vec<Scalar> = (0..m).map(|_| Scalar::random(rng)).collect();
 
@@ -169,19 +189,24 @@ impl ConstraintSystem {
             W_O,
             W_V,
         };
-        let prover_input = ProverInput { a_L, a_R, a_O, v_blinding };
+        let prover_input = ProverInput {
+            a_L,
+            a_R,
+            a_O,
+            v_blinding,
+        };
         let verifier_input = VerifierInput { V };
         (circuit, prover_input, verifier_input)
-	}
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use circuit_proof::CircuitProof;
+    use generators::Generators;
     use proof_transcript::ProofTranscript;
     use rand::rngs::OsRng;
-    use generators::Generators;
 
     fn create_and_verify_helper(
         circuit: Circuit,
@@ -214,333 +239,328 @@ mod tests {
         )
     }
 
-	#[test]
-	// 3 (const) * 4 (const) = 12 (const)
+    #[test]
+    // 3 (const) * 4 (const) = 12 (const)
     fn mul_circuit_constants_succeed() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let lc_a = LinearCombination::construct(vec![], Scalar::from_u64(3));
-    	let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(4));
-    	let lc_c = LinearCombination::construct(vec![], Scalar::from_u64(12));
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::construct(vec![], Scalar::from_u64(3));
+        let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(4));
+        let lc_c = LinearCombination::construct(vec![], Scalar::from_u64(12));
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_ok()
-    	);
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_ok());
     }
 
-	#[test]
-	// 3 (const) * 4 (const) != 10 (const)
+    #[test]
+    // 3 (const) * 4 (const) != 10 (const)
     fn mul_circuit_constants_fail() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let lc_a = LinearCombination::construct(vec![], Scalar::from_u64(3));
-    	let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(4));
-    	let lc_c = LinearCombination::construct(vec![], Scalar::from_u64(10));
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::construct(vec![], Scalar::from_u64(3));
+        let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(4));
+        let lc_c = LinearCombination::construct(vec![], Scalar::from_u64(10));
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_err()
-    	);
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_err());
     }
 
     #[test]
     // 3 (var) * 4 (var) = 12 (var)
     fn mul_circuit_variables_succeed() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(12));
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(12));
 
-    	let lc_a = LinearCombination::construct(vec![(var_a, Scalar::one())], Scalar::zero());
-    	let lc_b = LinearCombination::construct(vec![(var_b, Scalar::one())], Scalar::zero());
-    	let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
-		
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_ok()
-    	);
+        let lc_a = LinearCombination::construct(vec![(var_a, Scalar::one())], Scalar::zero());
+        let lc_b = LinearCombination::construct(vec![(var_b, Scalar::one())], Scalar::zero());
+        let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_ok());
     }
 
     #[test]
     // 3 (var) * 4 (var) != 10 (var)
     fn mul_circuit_variables_fail() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(10));
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(10));
 
-    	let lc_a = LinearCombination::construct(vec![(var_a, Scalar::one())], Scalar::zero());
-    	let lc_b = LinearCombination::construct(vec![(var_b, Scalar::one())], Scalar::zero());
-    	let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
-		
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_err()
-    	);
+        let lc_a = LinearCombination::construct(vec![(var_a, Scalar::one())], Scalar::zero());
+        let lc_b = LinearCombination::construct(vec![(var_b, Scalar::one())], Scalar::zero());
+        let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_err());
     }
 
     #[test]
     // ( 3 (var) * 2 (const) ) * ( 4 (var) * 5 (const) ) = 120 (var)
     fn mul_circuit_mixed_succeed() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(120));
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(120));
 
-    	let lc_a = LinearCombination::construct(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
-    	let lc_b = LinearCombination::construct(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
-    	let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
-		
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_ok()
-    	);
+        let lc_a = LinearCombination::construct(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
+        let lc_b = LinearCombination::construct(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
+        let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_ok());
     }
 
     #[test]
     // ( 3 (var) * 2 (const) ) * ( 4 (var) * 5 (const) ) != 121 (var)
     fn mul_circuit_mixed_fail() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(121));
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(121));
 
-    	let lc_a = LinearCombination::construct(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
-    	let lc_b = LinearCombination::construct(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
-    	let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
-		
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_err()
-    	);
+        let lc_a = LinearCombination::construct(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
+        let lc_b = LinearCombination::construct(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
+        let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_err());
     }
 
-
-	#[test]
-	// 3 (var) + 4 (var) = 7 (var)
+    #[test]
+    // 3 (var) + 4 (var) = 7 (var)
     fn add_circuit_variables_succeed() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(7));
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(7));
 
-    	let lc_a = LinearCombination::construct(vec![
-    		(var_a, Scalar::one()), 
-    		(var_b, Scalar::one()),
-    		(var_c, -Scalar::one()),
-    	], Scalar::zero());
-    	let lc_b = LinearCombination::construct(vec![], Scalar::one());
-    	let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::construct(
+            vec![
+                (var_a, Scalar::one()),
+                (var_b, Scalar::one()),
+                (var_c, -Scalar::one()),
+            ],
+            Scalar::zero(),
+        );
+        let lc_b = LinearCombination::construct(vec![], Scalar::one());
+        let lc_c = LinearCombination::construct(vec![], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_ok()
-    	);
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_ok());
     }
 
     #[test]
-	// 3 (var) + 4 (var) != 10 (var)
+    // 3 (var) + 4 (var) != 10 (var)
     fn add_circuit_variables_fail() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(10));
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(10));
 
-    	let lc_a = LinearCombination::construct(vec![
-    		(var_a, Scalar::one()), 
-    		(var_b, Scalar::one()),
-    		(var_c, -Scalar::one()),
-    	], Scalar::zero());
-    	let lc_b = LinearCombination::construct(vec![], Scalar::one());
-    	let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::construct(
+            vec![
+                (var_a, Scalar::one()),
+                (var_b, Scalar::one()),
+                (var_c, -Scalar::one()),
+            ],
+            Scalar::zero(),
+        );
+        let lc_b = LinearCombination::construct(vec![], Scalar::one());
+        let lc_c = LinearCombination::construct(vec![], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_err()
-    	);
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_err());
     }
 
-	#[test]
-	// 3 (var) + 4 (var) + 8 (const) = 15 (var)
+    #[test]
+    // 3 (var) + 4 (var) + 8 (const) = 15 (var)
     fn add_circuit_mixed_succeed() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(15));
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(15));
 
-    	let lc_a = LinearCombination::construct(vec![
-    		(var_a, Scalar::one()), 
-    		(var_b, Scalar::one()),
-    		(var_c, -Scalar::one()),
-    	], Scalar::from_u64(8));
-    	let lc_b = LinearCombination::construct(vec![], Scalar::one());
-    	let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::construct(
+            vec![
+                (var_a, Scalar::one()),
+                (var_b, Scalar::one()),
+                (var_c, -Scalar::one()),
+            ],
+            Scalar::from_u64(8),
+        );
+        let lc_b = LinearCombination::construct(vec![], Scalar::one());
+        let lc_c = LinearCombination::construct(vec![], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_ok()
-    	);
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_ok());
     }
 
-	#[test]
-	// 3 (var) + 4 (var) + 8 (const) != 16 (var)
+    #[test]
+    // 3 (var) + 4 (var) + 8 (const) != 16 (var)
     fn add_circuit_mixed_fail() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(16));
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(16));
 
-    	let lc_a = LinearCombination::construct(vec![
-    		(var_a, Scalar::one()), 
-    		(var_b, Scalar::one()),
-    		(var_c, -Scalar::one()),
-    	], Scalar::from_u64(8));
-    	let lc_b = LinearCombination::construct(vec![], Scalar::one());
-    	let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::construct(
+            vec![
+                (var_a, Scalar::one()),
+                (var_b, Scalar::one()),
+                (var_c, -Scalar::one()),
+            ],
+            Scalar::from_u64(8),
+        );
+        let lc_b = LinearCombination::construct(vec![], Scalar::one());
+        let lc_c = LinearCombination::construct(vec![], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_err()
-    	);
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_err());
     }
 
     #[test]
-    // ( 3 (var) + 4 (var) + 8 (const) - 13 (var) ) * 2 (const) = 1 (var) * 4 (const) 
+    // ( 3 (var) + 4 (var) + 8 (const) - 13 (var) ) * 2 (const) = 1 (var) * 4 (const)
     fn add_and_multiply_circuit_succeed() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(13));
-    	let var_d = cs.alloc_variable(Scalar::one());
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(13));
+        let var_d = cs.alloc_variable(Scalar::one());
 
-    	let lc_a = LinearCombination::construct(vec![
-    		(var_a, Scalar::one()), 
-    		(var_b, Scalar::one()),
-    		(var_c, -Scalar::one()),
-    	], Scalar::from_u64(8));
-    	let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(2));
-    	let lc_c = LinearCombination::construct(vec![(var_d, Scalar::from_u64(4))], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::construct(
+            vec![
+                (var_a, Scalar::one()),
+                (var_b, Scalar::one()),
+                (var_c, -Scalar::one()),
+            ],
+            Scalar::from_u64(8),
+        );
+        let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(2));
+        let lc_c = LinearCombination::construct(vec![(var_d, Scalar::from_u64(4))], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_ok()
-    	);    	
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_ok());
     }
 
     #[test]
-    // ( 3 (var) + 4 (var) + 8 (const) - 13 (var) ) * 2 (const) = 1 (var) * 3 (const) 
+    // ( 3 (var) + 4 (var) + 8 (const) - 13 (var) ) * 2 (const) = 1 (var) * 3 (const)
     fn add_and_multiply_circuit_fail() {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
 
-    	let var_a = cs.alloc_variable(Scalar::from_u64(3));
-    	let var_b = cs.alloc_variable(Scalar::from_u64(4));
-    	let var_c = cs.alloc_variable(Scalar::from_u64(13));
-    	let var_d = cs.alloc_variable(Scalar::one());
+        let var_a = cs.alloc_variable(Scalar::from_u64(3));
+        let var_b = cs.alloc_variable(Scalar::from_u64(4));
+        let var_c = cs.alloc_variable(Scalar::from_u64(13));
+        let var_d = cs.alloc_variable(Scalar::one());
 
-    	let lc_a = LinearCombination::construct(vec![
-    		(var_a, Scalar::one()), 
-    		(var_b, Scalar::one()),
-    		(var_c, -Scalar::one()),
-    	], Scalar::from_u64(8));
-    	let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(2));
-    	let lc_c = LinearCombination::construct(vec![(var_d, Scalar::from_u64(3))], Scalar::zero());
-    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::construct(
+            vec![
+                (var_a, Scalar::one()),
+                (var_b, Scalar::one()),
+                (var_c, -Scalar::one()),
+            ],
+            Scalar::from_u64(8),
+        );
+        let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(2));
+        let lc_c = LinearCombination::construct(vec![(var_d, Scalar::from_u64(3))], Scalar::zero());
+        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	assert!(
-    		create_and_verify_helper(circuit, prover_input, verifier_input)
-    			.is_err()
-    	);    	
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        assert!(create_and_verify_helper(circuit, prover_input, verifier_input).is_err());
     }
 
     // Creates a 2 in 2 out shuffle circuit.
     fn shuffle_circuit_helper(
-    	in_0: Scalar, 
-    	in_1: Scalar, 
-    	out_0: Scalar, 
-    	out_1: Scalar,
+        in_0: Scalar,
+        in_1: Scalar,
+        out_0: Scalar,
+        out_1: Scalar,
     ) -> Result<(), &'static str> {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
         let z = Scalar::random(&mut rng);
 
-    	let var_in_0 = cs.alloc_variable(in_0);
-    	let var_in_1 = cs.alloc_variable(in_1);
-    	let var_out_0 = cs.alloc_variable(out_0);
-    	let var_out_1 = cs.alloc_variable(out_1);
-    	let var_mul = cs.alloc_variable((in_0 - z) * (in_1 - z));
+        let var_in_0 = cs.alloc_variable(in_0);
+        let var_in_1 = cs.alloc_variable(in_1);
+        let var_out_0 = cs.alloc_variable(out_0);
+        let var_out_1 = cs.alloc_variable(out_1);
+        let var_mul = cs.alloc_variable((in_0 - z) * (in_1 - z));
 
-    	// lc_0: (var_in_0 - z) * (var_in_1 - z) = var_mul
-    	let lc_0_a = LinearCombination::construct(vec![(var_in_0, Scalar::one())], -z);
-    	let lc_0_b = LinearCombination::construct(vec![(var_in_1, Scalar::one())], -z);
-    	let lc_0_c = LinearCombination::construct(vec![(var_mul.clone(), Scalar::one())], Scalar::zero());
-    	assert!(cs.push_lc(lc_0_a, lc_0_b, lc_0_c).is_ok());
+        // lc_0: (var_in_0 - z) * (var_in_1 - z) = var_mul
+        let lc_0_a = LinearCombination::construct(vec![(var_in_0, Scalar::one())], -z);
+        let lc_0_b = LinearCombination::construct(vec![(var_in_1, Scalar::one())], -z);
+        let lc_0_c =
+            LinearCombination::construct(vec![(var_mul.clone(), Scalar::one())], Scalar::zero());
+        assert!(cs.push_lc(lc_0_a, lc_0_b, lc_0_c).is_ok());
 
-    	// lc_1: (var_out_0 - z) * (var_out_1 - z) = var_mul
-    	let lc_1_a = LinearCombination::construct(vec![(var_out_0, Scalar::one())], -z);
-    	let lc_1_b = LinearCombination::construct(vec![(var_out_1, Scalar::one())], -z);
-    	let lc_1_c = LinearCombination::construct(vec![(var_mul, Scalar::one())], Scalar::zero());
-    	assert!(cs.push_lc(lc_1_a, lc_1_b, lc_1_c).is_ok());	
+        // lc_1: (var_out_0 - z) * (var_out_1 - z) = var_mul
+        let lc_1_a = LinearCombination::construct(vec![(var_out_0, Scalar::one())], -z);
+        let lc_1_b = LinearCombination::construct(vec![(var_out_1, Scalar::one())], -z);
+        let lc_1_c = LinearCombination::construct(vec![(var_mul, Scalar::one())], Scalar::zero());
+        assert!(cs.push_lc(lc_1_a, lc_1_b, lc_1_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-		create_and_verify_helper(circuit, prover_input, verifier_input)  	
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        create_and_verify_helper(circuit, prover_input, verifier_input)
     }
 
     #[test]
@@ -548,22 +568,10 @@ mod tests {
     fn shuffle_circuit() {
         let three = Scalar::from_u64(3);
         let seven = Scalar::from_u64(7);
-        assert!(
-        	shuffle_circuit_helper(three, seven, seven, three)
-        		.is_ok()
-        );
-        assert!(
-        	shuffle_circuit_helper(three, seven, seven, three)
-        		.is_ok()
-        );
-        assert!(
-        	shuffle_circuit_helper(three, seven, seven, seven)
-        		.is_err()
-        );
-        assert!(
-        	shuffle_circuit_helper(three, Scalar::one(), seven, three)
-        		.is_err()
-        );
+        assert!(shuffle_circuit_helper(three, seven, seven, three).is_ok());
+        assert!(shuffle_circuit_helper(three, seven, seven, three).is_ok());
+        assert!(shuffle_circuit_helper(three, seven, seven, seven).is_err());
+        assert!(shuffle_circuit_helper(three, Scalar::one(), seven, three).is_err());
     }
 
     // Creates a 2 in 2 out merge circuit.
@@ -572,16 +580,16 @@ mod tests {
     // Or the assets are merged. This is allowed when:
     // the types are the same, the asset values are merged into out_1, and out_0 is zero: $30 + $42 = $0 + $72
     fn merge_circuit_helper(
-    	type_0: Scalar,
-    	type_1: Scalar,
-    	val_in_0: Scalar, 
-    	val_in_1: Scalar, 
-    	val_out_0: Scalar, 
-    	val_out_1: Scalar,
+        type_0: Scalar,
+        type_1: Scalar,
+        val_in_0: Scalar,
+        val_in_1: Scalar,
+        val_out_0: Scalar,
+        val_out_1: Scalar,
     ) -> Result<(), &'static str> {
-    	let mut rng = OsRng::new().unwrap();
-    	let pedersen_generators = PedersenGenerators::default();
-    	let mut cs = ConstraintSystem::new();
+        let mut rng = OsRng::new().unwrap();
+        let pedersen_generators = PedersenGenerators::default();
+        let mut cs = ConstraintSystem::new();
         let c = Scalar::random(&mut rng);
 
         let t_0 = cs.alloc_variable(type_0);
@@ -591,62 +599,51 @@ mod tests {
         let out_0 = cs.alloc_variable(val_out_0);
         let out_1 = cs.alloc_variable(val_out_1);
 
-		// lc_a: in_0 * (-1) + in_1 * (-c) + out_0 + out_1 * (c)
-        let lc_a = LinearCombination::construct(vec![
-        	(in_0.clone(), -Scalar::one()),
-        	(in_1.clone(), -c),
-        	(out_0.clone(), Scalar::one()),
-        	(out_1.clone(), c),
-        ], Scalar::zero());
-    	// lc_b: in_0 + in_1 + out_1 * (-1) + out_0 * (c) + t_0 * (-c*c) + t_1 * (c*c)
-        let lc_b = LinearCombination::construct(vec![
-        	(in_0, Scalar::one()),
-        	(in_1, Scalar::one()),
-        	(out_1, -Scalar::one()),
-        	(out_0, c),
-        	(t_0, -c*c),
-        	(t_1, c*c),
-        ], Scalar::zero());  
+        // lc_a: in_0 * (-1) + in_1 * (-c) + out_0 + out_1 * (c)
+        let lc_a = LinearCombination::construct(
+            vec![
+                (in_0.clone(), -Scalar::one()),
+                (in_1.clone(), -c),
+                (out_0.clone(), Scalar::one()),
+                (out_1.clone(), c),
+            ],
+            Scalar::zero(),
+        );
+        // lc_b: in_0 + in_1 + out_1 * (-1) + out_0 * (c) + t_0 * (-c*c) + t_1 * (c*c)
+        let lc_b = LinearCombination::construct(
+            vec![
+                (in_0, Scalar::one()),
+                (in_1, Scalar::one()),
+                (out_1, -Scalar::one()),
+                (out_0, c),
+                (t_0, -c * c),
+                (t_1, c * c),
+            ],
+            Scalar::zero(),
+        );
         let lc_c = LinearCombination::construct(vec![], Scalar::zero());
 
         assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
-    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
-    	create_and_verify_helper(circuit, prover_input, verifier_input)
+        let (circuit, prover_input, verifier_input) =
+            cs.create_proof_input(&pedersen_generators, &mut rng);
+        create_and_verify_helper(circuit, prover_input, verifier_input)
     }
 
     #[test]
     fn merge_circuit() {
-    	let buck = Scalar::from_u64(32);
-    	let yuan = Scalar::from_u64(86);
-    	let a = Scalar::from_u64(24);
-    	let b = Scalar::from_u64(76);
-    	let a_plus_b = Scalar::from_u64(100);
-    	let zero = Scalar::zero();
+        let buck = Scalar::from_u64(32);
+        let yuan = Scalar::from_u64(86);
+        let a = Scalar::from_u64(24);
+        let b = Scalar::from_u64(76);
+        let a_plus_b = Scalar::from_u64(100);
+        let zero = Scalar::zero();
 
-        assert!(
-        	merge_circuit_helper(buck, buck, a, a, a, a)
-        		.is_ok()
-        );
-        assert!(
-        	merge_circuit_helper(buck, buck, a, b, zero, a_plus_b)
-        		.is_ok()
-        );
-        assert!(
-        	merge_circuit_helper(buck, yuan, a, b, a, b)
-        		.is_ok()
-        );
-        assert!(
-        	merge_circuit_helper(buck, buck, a, b, a, a_plus_b)
-        		.is_err()
-        );
-        assert!(
-        	merge_circuit_helper(buck, yuan, a, b, zero, a_plus_b)
-        		.is_err()
-        );
-        assert!(
-        	merge_circuit_helper(buck, buck, a, b, zero, zero)
-        		.is_err()
-        );
+        assert!(merge_circuit_helper(buck, buck, a, a, a, a).is_ok());
+        assert!(merge_circuit_helper(buck, buck, a, b, zero, a_plus_b).is_ok());
+        assert!(merge_circuit_helper(buck, yuan, a, b, a, b).is_ok());
+        assert!(merge_circuit_helper(buck, buck, a, b, a, a_plus_b).is_err());
+        assert!(merge_circuit_helper(buck, yuan, a, b, zero, a_plus_b).is_err());
+        assert!(merge_circuit_helper(buck, buck, a, b, zero, zero).is_err());
     }
 }

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -224,7 +224,7 @@ mod tests {
     	let lc_a = LinearCombination::construct(vec![], Scalar::from_u64(3));
     	let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(4));
     	let lc_c = LinearCombination::construct(vec![], Scalar::from_u64(12));
-    	cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -243,7 +243,7 @@ mod tests {
     	let lc_a = LinearCombination::construct(vec![], Scalar::from_u64(3));
     	let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(4));
     	let lc_c = LinearCombination::construct(vec![], Scalar::from_u64(10));
-    	cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -266,7 +266,7 @@ mod tests {
     	let lc_a = LinearCombination::construct(vec![(var_a, Scalar::one())], Scalar::zero());
     	let lc_b = LinearCombination::construct(vec![(var_b, Scalar::one())], Scalar::zero());
     	let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-		cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 		
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -289,7 +289,7 @@ mod tests {
     	let lc_a = LinearCombination::construct(vec![(var_a, Scalar::one())], Scalar::zero());
     	let lc_b = LinearCombination::construct(vec![(var_b, Scalar::one())], Scalar::zero());
     	let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-		cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 		
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -312,7 +312,7 @@ mod tests {
     	let lc_a = LinearCombination::construct(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
     	let lc_b = LinearCombination::construct(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
     	let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-		cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 		
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -335,7 +335,7 @@ mod tests {
     	let lc_a = LinearCombination::construct(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
     	let lc_b = LinearCombination::construct(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
     	let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-		cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 		
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -363,7 +363,7 @@ mod tests {
     	], Scalar::zero());
     	let lc_b = LinearCombination::construct(vec![], Scalar::one());
     	let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-    	cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -390,7 +390,7 @@ mod tests {
     	], Scalar::zero());
     	let lc_b = LinearCombination::construct(vec![], Scalar::one());
     	let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-    	cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -417,7 +417,7 @@ mod tests {
     	], Scalar::from_u64(8));
     	let lc_b = LinearCombination::construct(vec![], Scalar::one());
     	let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-    	cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -444,7 +444,7 @@ mod tests {
     	], Scalar::from_u64(8));
     	let lc_b = LinearCombination::construct(vec![], Scalar::one());
     	let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-    	cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -472,7 +472,7 @@ mod tests {
     	], Scalar::from_u64(8));
     	let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(2));
     	let lc_c = LinearCombination::construct(vec![(var_d, Scalar::from_u64(4))], Scalar::zero());
-    	cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
 
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(
@@ -500,7 +500,85 @@ mod tests {
     	], Scalar::from_u64(8));
     	let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(2));
     	let lc_c = LinearCombination::construct(vec![(var_d, Scalar::from_u64(3))], Scalar::zero());
-    	cs.push_lc(lc_a, lc_b, lc_c);
+    	assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+
+    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
+    	assert!(
+    		create_and_verify_helper(circuit, prover_input, verifier_input)
+    			.is_err()
+    	);    	
+    }
+
+    #[test]
+    // Test that a 2 in 2 out shuffle circuit succeeds
+    // lc_0: (var_0 - z) * (var_1 - z) = var_4
+    // lc_1: (var_2 - z) * (var_3 - z) = var_4
+    // var_0 and var_3 = 3
+    // var_1 and var_2 = 7
+    fn shuffle_circuit_succeed() {
+    	let mut rng = OsRng::new().unwrap();
+    	let pedersen_generators = PedersenGenerators::default();
+    	let mut cs = ConstraintSystem::new();
+        let z = Scalar::random(&mut rng);
+
+        let three = Scalar::from_u64(3);
+        let seven = Scalar::from_u64(7);
+    	let var_0 = cs.alloc_variable(three);
+    	let var_1 = cs.alloc_variable(seven);
+    	let var_2 = cs.alloc_variable(seven);
+    	let var_3 = cs.alloc_variable(three);
+    	let var_4 = cs.alloc_variable((three - z) * (seven - z));
+
+    	// lc_0: (var_0 - z) * (var_1 - z) = var_4
+    	let lc_0_a = LinearCombination::construct(vec![(var_0, Scalar::one())], -z);
+    	let lc_0_b = LinearCombination::construct(vec![(var_1, Scalar::one())], -z);
+    	let lc_0_c = LinearCombination::construct(vec![(var_4.clone(), Scalar::one())], Scalar::zero());
+    	assert!(cs.push_lc(lc_0_a, lc_0_b, lc_0_c).is_ok());
+
+    	// lc_1: (var_2 - z) * (var_3 - z) = var_4
+    	let lc_1_a = LinearCombination::construct(vec![(var_2, Scalar::one())], -z);
+    	let lc_1_b = LinearCombination::construct(vec![(var_3, Scalar::one())], -z);
+    	let lc_1_c = LinearCombination::construct(vec![(var_4, Scalar::one())], Scalar::zero());
+    	assert!(cs.push_lc(lc_1_a, lc_1_b, lc_1_c).is_ok());
+
+    	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
+    	assert!(
+    		create_and_verify_helper(circuit, prover_input, verifier_input)
+    			.is_ok()
+    	);    	
+    }
+
+    #[test]
+    // Test that a 2 in 2 out shuffle circuit fails
+    // lc_0: (var_0 - z) * (var_1 - z) = var_4
+    // lc_1: (var_2 - z) * (var_3 - z) = var_4
+    // var_0 = 3
+    // var_1 and var_2 and var_3 = 7
+    fn shuffle_circuit_fail() {
+    	let mut rng = OsRng::new().unwrap();
+    	let pedersen_generators = PedersenGenerators::default();
+    	let mut cs = ConstraintSystem::new();
+        let z = Scalar::random(&mut rng);
+
+        let three = Scalar::from_u64(3);
+        let seven = Scalar::from_u64(7);
+    	let var_0 = cs.alloc_variable(three);
+    	let var_1 = cs.alloc_variable(seven);
+    	let var_2 = cs.alloc_variable(seven);
+    	let var_3 = cs.alloc_variable(seven);
+    	let var_4 = cs.alloc_variable((three - z) * (seven - z));
+
+    	// lc_0: (var_0 - z) * (var_1 - z) = var_4
+    	let lc_0_a = LinearCombination::construct(vec![(var_0, Scalar::one())], -z);
+    	let lc_0_b = LinearCombination::construct(vec![(var_1, Scalar::one())], -z);
+    	let lc_0_c = LinearCombination::construct(vec![(var_4.clone(), Scalar::one())], Scalar::zero());
+    	assert!(cs.push_lc(lc_0_a, lc_0_b, lc_0_c).is_ok());
+
+    	// lc_1: (var_2 - z) * (var_3 - z) = var_4
+    	let lc_1_a = LinearCombination::construct(vec![(var_2, Scalar::one())], -z);
+    	let lc_1_b = LinearCombination::construct(vec![(var_3, Scalar::one())], -z);
+    	let lc_1_c = LinearCombination::construct(vec![(var_4, Scalar::one())], Scalar::zero());
+    	assert!(cs.push_lc(lc_1_a, lc_1_b, lc_1_c).is_ok());
 
     	let (circuit, prover_input, verifier_input) = cs.create_proof_input(&pedersen_generators, &mut rng);
     	assert!(

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -133,7 +133,7 @@ impl ConstraintSystem {
 			W_O[i + 2*n][i] = one;
 		}
 
-		// TODO: can create / append to c on the fly instead
+		// TODO: create / append to c on the fly instead
 		let mut c = vec![zer; q]; // length q vector of constants.
 		let mut W_V = vec![vec![zer; m]; q]; // qxm matrix of commitments.
 		for (i, lc) in self.a.iter().chain(self.b.iter()).chain(self.c.iter()).enumerate() {
@@ -142,6 +142,8 @@ impl ConstraintSystem {
 			}
 			c[i] = lc.get_constant();
 		};
+
+		let mut rng = OsRng::new().unwrap();
 
 		let circuit = Circuit {
 			n, m, q, c,
@@ -155,9 +157,8 @@ impl ConstraintSystem {
 }
 
 #[cfg(test)]
-	mod tests {
+mod tests {
     use super::*; 
-
 	#[test]
 	// trivial case using constant multiplication
     fn mul_circuit_constants() {

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -8,7 +8,7 @@ use std::iter::FromIterator;
 use circuit_proof::{Circuit, ProverInput, VerifierInput};
 
 // This is a stripped-down version of the Bellman r1cs representation, for the purposes of
-// learning / understanding. The eventual goal is to write this as a BulletproofsConstraintSystem 
+// learning / understanding. The eventual goal is to write this as a BulletproofsConstraintSystem
 // that implements the Bellman ConstraintSystem trait, so we can use that code/logic.
 // (That would require the bellman code to be decoupled from the underlying pairings.)
 
@@ -76,7 +76,7 @@ impl ConstraintSystem {
         lc_b: LinearCombination,
         lc_c: LinearCombination,
     ) -> Result<(), &'static str> {
-        // TODO: check that the linear combinations are valid 
+        // TODO: check that the linear combinations are valid
         // (e.g. that variables are valid, belong to this constraint system).
         self.a.push(lc_a);
         self.b.push(lc_b);
@@ -85,18 +85,18 @@ impl ConstraintSystem {
     }
 
     fn eval_lc(&self, lc: &LinearCombination) -> Scalar {
-        let sum_vars: Scalar = 
-            lc.variables
+        let sum_vars: Scalar = lc
+            .variables
             .iter()
             .map(|(var, scalar)| scalar * self.var_assignment[var.0])
             .sum();
-        sum_vars + lc.constant        
+        sum_vars + lc.constant
     }
 
-    fn create_verifier_input (
-    	&self,
-    	v_blinding: &Vec<Scalar>,
-    	pedersen_generators: &PedersenGenerators,
+    fn create_verifier_input(
+        &self,
+        v_blinding: &Vec<Scalar>,
+        pedersen_generators: &PedersenGenerators,
     ) -> VerifierInput {
         let V: Vec<RistrettoPoint> = self
             .var_assignment
@@ -104,34 +104,19 @@ impl ConstraintSystem {
             .zip(v_blinding)
             .map(|(v_i, v_blinding_i)| pedersen_generators.commit(*v_i, *v_blinding_i))
             .collect();
-        VerifierInput { V }	
+        VerifierInput { V }
     }
 
-    fn create_prover_input(
-    	&self,
-    	v_blinding: &Vec<Scalar>
-    ) -> ProverInput {
+    fn create_prover_input(&self, v_blinding: &Vec<Scalar>) -> ProverInput {
         // eval a, b, c and assign results to a_L, a_R, a_O respectively
-        let a_L: Vec<Scalar> = self
-            .a
-            .iter()
-            .map(|lc| self.eval_lc(&lc))
-            .collect();
-        let a_R: Vec<Scalar> = self
-            .b
-            .iter()
-            .map(|lc| self.eval_lc(&lc))
-            .collect();
-        let a_O: Vec<Scalar> = self
-            .c
-            .iter()
-            .map(|lc| self.eval_lc(&lc))
-            .collect();
+        let a_L: Vec<Scalar> = self.a.iter().map(|lc| self.eval_lc(&lc)).collect();
+        let a_R: Vec<Scalar> = self.b.iter().map(|lc| self.eval_lc(&lc)).collect();
+        let a_O: Vec<Scalar> = self.c.iter().map(|lc| self.eval_lc(&lc)).collect();
         ProverInput {
-        	a_L,
-        	a_R, 
-        	a_O,
-        	v_blinding: v_blinding.to_vec(),
+            a_L,
+            a_R,
+            a_O,
+            v_blinding: v_blinding.to_vec(),
         }
     }
 
@@ -187,10 +172,10 @@ impl ConstraintSystem {
         pedersen_generators: &PedersenGenerators,
         rng: &mut R,
     ) -> (Circuit, ProverInput, VerifierInput) {
-    	let m = self.var_assignment.len();
+        let m = self.var_assignment.len();
         let v_blinding: Vec<Scalar> = (0..m).map(|_| Scalar::random(rng)).collect();
 
-    	let circuit = self.create_circuit();
+        let circuit = self.create_circuit();
         let prover_input = self.create_prover_input(&v_blinding);
         let verifier_input = self.create_verifier_input(&v_blinding, pedersen_generators);
 
@@ -546,8 +531,7 @@ mod tests {
         // lc_0: (var_in_0 - z) * (var_in_1 - z) = var_mul
         let lc_0_a = LinearCombination::new(vec![(var_in_0, Scalar::one())], -z);
         let lc_0_b = LinearCombination::new(vec![(var_in_1, Scalar::one())], -z);
-        let lc_0_c =
-            LinearCombination::new(vec![(var_mul.clone(), Scalar::one())], Scalar::zero());
+        let lc_0_c = LinearCombination::new(vec![(var_mul.clone(), Scalar::one())], Scalar::zero());
         assert!(cs.constrain(lc_0_a, lc_0_b, lc_0_c).is_ok());
 
         // lc_1: (var_out_0 - z) * (var_out_1 - z) = var_mul

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -40,6 +40,15 @@ impl LinearCombination {
 	pub fn get_variables(&self) -> Vec<Variable> {
 		self.variables.iter().map(|(var, _)| var.clone()).collect()
 	}
+
+	// evaluate the linear combination, given the variable values in var_assignment
+	pub fn eval(&self, var_assignment: &Vec<Scalar>) -> Scalar {
+		let sum_vars: Scalar = self.variables.iter()
+					.map(|(var, scalar)|
+						scalar * var_assignment[var.get_index()]
+					).sum();
+		sum_vars + self.constant
+	}
 }
 
 /// Represents a vector of groups of 3 linear combinations, where a * b = c
@@ -93,8 +102,19 @@ impl ConstraintSystem {
 	}
 
 	pub fn create_proof_input(&self) -> (Circuit, CircuitInput) {
-		// eval a, b, c - to know what values to assign to variables
-		
+		// naive conversion that doesn't do any multiplication elimination
+		let n = self.a.len();
+		let m = self.var_assignment.len();
+		let q = self.a.len() * 3;
+
+		// eval a, b, c and assign results to a_L, a_R, a_O respectively
+		let a_L: Vec<Scalar> = 
+			self.a.iter().map(|lc| lc.eval(&self.var_assignment)).collect();
+		let a_R: Vec<Scalar> = 
+			self.b.iter().map(|lc| lc.eval(&self.var_assignment)).collect();
+		let a_O: Vec<Scalar> = 
+			self.c.iter().map(|lc| lc.eval(&self.var_assignment)).collect();
+
 		unimplemented!();
 	}
 }

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -568,7 +568,7 @@ mod tests {
     fn shuffle_circuit() {
         let three = Scalar::from_u64(3);
         let seven = Scalar::from_u64(7);
-        assert!(shuffle_circuit_helper(three, seven, seven, three).is_ok());
+        assert!(shuffle_circuit_helper(three, seven, three, seven).is_ok());
         assert!(shuffle_circuit_helper(three, seven, seven, three).is_ok());
         assert!(shuffle_circuit_helper(three, seven, seven, seven).is_err());
         assert!(shuffle_circuit_helper(three, Scalar::one(), seven, three).is_err());

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -8,16 +8,16 @@ use std::iter::FromIterator;
 use circuit_proof::{Circuit, ProverInput, VerifierInput};
 
 // This is a stripped-down version of the Bellman r1cs representation, for the purposes of
-// learning / understanding. The goal is to write this as a BulletproofsConstraintSystem that
-// implements the Bellman ConstraintSystem trait, so we can use that code/logic.
+// learning / understanding. The eventual goal is to write this as a BulletproofsConstraintSystem 
+// that implements the Bellman ConstraintSystem trait, so we can use that code/logic.
 // (That would require the bellman code to be decoupled from the underlying pairings.)
 
 /// Represents a variable in our constraint system, where the value represents the index.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Variable(usize);
 
 impl Variable {
-    pub fn get_index(&self) -> usize {
+    fn get_index(&self) -> usize {
         self.0
     }
 }
@@ -32,7 +32,7 @@ pub struct LinearCombination {
 impl LinearCombination {
     // TODO: make constructor with iterators
     // see FromIterator trait - [(a1, v1), (a2, v2)].iter().collect() (pass in the iterator, collect to get LC)
-    pub fn construct(variables: Vec<(Variable, Scalar)>, constant: Scalar) -> Self {
+    pub fn new(variables: Vec<(Variable, Scalar)>, constant: Scalar) -> Self {
         LinearCombination {
             variables,
             constant,
@@ -97,7 +97,7 @@ impl ConstraintSystem {
 
     // Push one set of linear constraints (a, b, c) to the constraint system.
     // Pushing a, b, c together prevents mismatched constraints.
-    pub fn push_lc(
+    pub fn constrain(
         &mut self,
         lc_a: LinearCombination,
         lc_b: LinearCombination,
@@ -264,10 +264,10 @@ mod tests {
         let pedersen_generators = PedersenGenerators::default();
         let mut cs = ConstraintSystem::new();
 
-        let lc_a = LinearCombination::construct(vec![], Scalar::from_u64(3));
-        let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(4));
-        let lc_c = LinearCombination::construct(vec![], Scalar::from_u64(12));
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::new(vec![], Scalar::from_u64(3));
+        let lc_b = LinearCombination::new(vec![], Scalar::from_u64(4));
+        let lc_c = LinearCombination::new(vec![], Scalar::from_u64(12));
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -281,10 +281,10 @@ mod tests {
         let pedersen_generators = PedersenGenerators::default();
         let mut cs = ConstraintSystem::new();
 
-        let lc_a = LinearCombination::construct(vec![], Scalar::from_u64(3));
-        let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(4));
-        let lc_c = LinearCombination::construct(vec![], Scalar::from_u64(10));
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::new(vec![], Scalar::from_u64(3));
+        let lc_b = LinearCombination::new(vec![], Scalar::from_u64(4));
+        let lc_c = LinearCombination::new(vec![], Scalar::from_u64(10));
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -302,10 +302,10 @@ mod tests {
         let var_b = cs.alloc_variable(Scalar::from_u64(4));
         let var_c = cs.alloc_variable(Scalar::from_u64(12));
 
-        let lc_a = LinearCombination::construct(vec![(var_a, Scalar::one())], Scalar::zero());
-        let lc_b = LinearCombination::construct(vec![(var_b, Scalar::one())], Scalar::zero());
-        let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::new(vec![(var_a, Scalar::one())], Scalar::zero());
+        let lc_b = LinearCombination::new(vec![(var_b, Scalar::one())], Scalar::zero());
+        let lc_c = LinearCombination::new(vec![(var_c, Scalar::one())], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -323,10 +323,10 @@ mod tests {
         let var_b = cs.alloc_variable(Scalar::from_u64(4));
         let var_c = cs.alloc_variable(Scalar::from_u64(10));
 
-        let lc_a = LinearCombination::construct(vec![(var_a, Scalar::one())], Scalar::zero());
-        let lc_b = LinearCombination::construct(vec![(var_b, Scalar::one())], Scalar::zero());
-        let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::new(vec![(var_a, Scalar::one())], Scalar::zero());
+        let lc_b = LinearCombination::new(vec![(var_b, Scalar::one())], Scalar::zero());
+        let lc_c = LinearCombination::new(vec![(var_c, Scalar::one())], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -344,10 +344,10 @@ mod tests {
         let var_b = cs.alloc_variable(Scalar::from_u64(4));
         let var_c = cs.alloc_variable(Scalar::from_u64(120));
 
-        let lc_a = LinearCombination::construct(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
-        let lc_b = LinearCombination::construct(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
-        let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::new(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
+        let lc_b = LinearCombination::new(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
+        let lc_c = LinearCombination::new(vec![(var_c, Scalar::one())], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -365,10 +365,10 @@ mod tests {
         let var_b = cs.alloc_variable(Scalar::from_u64(4));
         let var_c = cs.alloc_variable(Scalar::from_u64(121));
 
-        let lc_a = LinearCombination::construct(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
-        let lc_b = LinearCombination::construct(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
-        let lc_c = LinearCombination::construct(vec![(var_c, Scalar::one())], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_a = LinearCombination::new(vec![(var_a, Scalar::from_u64(2))], Scalar::zero());
+        let lc_b = LinearCombination::new(vec![(var_b, Scalar::from_u64(5))], Scalar::zero());
+        let lc_c = LinearCombination::new(vec![(var_c, Scalar::one())], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -386,7 +386,7 @@ mod tests {
         let var_b = cs.alloc_variable(Scalar::from_u64(4));
         let var_c = cs.alloc_variable(Scalar::from_u64(7));
 
-        let lc_a = LinearCombination::construct(
+        let lc_a = LinearCombination::new(
             vec![
                 (var_a, Scalar::one()),
                 (var_b, Scalar::one()),
@@ -394,9 +394,9 @@ mod tests {
             ],
             Scalar::zero(),
         );
-        let lc_b = LinearCombination::construct(vec![], Scalar::one());
-        let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_b = LinearCombination::new(vec![], Scalar::one());
+        let lc_c = LinearCombination::new(vec![], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -414,7 +414,7 @@ mod tests {
         let var_b = cs.alloc_variable(Scalar::from_u64(4));
         let var_c = cs.alloc_variable(Scalar::from_u64(10));
 
-        let lc_a = LinearCombination::construct(
+        let lc_a = LinearCombination::new(
             vec![
                 (var_a, Scalar::one()),
                 (var_b, Scalar::one()),
@@ -422,9 +422,9 @@ mod tests {
             ],
             Scalar::zero(),
         );
-        let lc_b = LinearCombination::construct(vec![], Scalar::one());
-        let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_b = LinearCombination::new(vec![], Scalar::one());
+        let lc_c = LinearCombination::new(vec![], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -442,7 +442,7 @@ mod tests {
         let var_b = cs.alloc_variable(Scalar::from_u64(4));
         let var_c = cs.alloc_variable(Scalar::from_u64(15));
 
-        let lc_a = LinearCombination::construct(
+        let lc_a = LinearCombination::new(
             vec![
                 (var_a, Scalar::one()),
                 (var_b, Scalar::one()),
@@ -450,9 +450,9 @@ mod tests {
             ],
             Scalar::from_u64(8),
         );
-        let lc_b = LinearCombination::construct(vec![], Scalar::one());
-        let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_b = LinearCombination::new(vec![], Scalar::one());
+        let lc_c = LinearCombination::new(vec![], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -470,7 +470,7 @@ mod tests {
         let var_b = cs.alloc_variable(Scalar::from_u64(4));
         let var_c = cs.alloc_variable(Scalar::from_u64(16));
 
-        let lc_a = LinearCombination::construct(
+        let lc_a = LinearCombination::new(
             vec![
                 (var_a, Scalar::one()),
                 (var_b, Scalar::one()),
@@ -478,9 +478,9 @@ mod tests {
             ],
             Scalar::from_u64(8),
         );
-        let lc_b = LinearCombination::construct(vec![], Scalar::one());
-        let lc_c = LinearCombination::construct(vec![], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_b = LinearCombination::new(vec![], Scalar::one());
+        let lc_c = LinearCombination::new(vec![], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -499,7 +499,7 @@ mod tests {
         let var_c = cs.alloc_variable(Scalar::from_u64(13));
         let var_d = cs.alloc_variable(Scalar::one());
 
-        let lc_a = LinearCombination::construct(
+        let lc_a = LinearCombination::new(
             vec![
                 (var_a, Scalar::one()),
                 (var_b, Scalar::one()),
@@ -507,9 +507,9 @@ mod tests {
             ],
             Scalar::from_u64(8),
         );
-        let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(2));
-        let lc_c = LinearCombination::construct(vec![(var_d, Scalar::from_u64(4))], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_b = LinearCombination::new(vec![], Scalar::from_u64(2));
+        let lc_c = LinearCombination::new(vec![(var_d, Scalar::from_u64(4))], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -528,7 +528,7 @@ mod tests {
         let var_c = cs.alloc_variable(Scalar::from_u64(13));
         let var_d = cs.alloc_variable(Scalar::one());
 
-        let lc_a = LinearCombination::construct(
+        let lc_a = LinearCombination::new(
             vec![
                 (var_a, Scalar::one()),
                 (var_b, Scalar::one()),
@@ -536,9 +536,9 @@ mod tests {
             ],
             Scalar::from_u64(8),
         );
-        let lc_b = LinearCombination::construct(vec![], Scalar::from_u64(2));
-        let lc_c = LinearCombination::construct(vec![(var_d, Scalar::from_u64(3))], Scalar::zero());
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        let lc_b = LinearCombination::new(vec![], Scalar::from_u64(2));
+        let lc_c = LinearCombination::new(vec![(var_d, Scalar::from_u64(3))], Scalar::zero());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -564,17 +564,17 @@ mod tests {
         let var_mul = cs.alloc_variable((in_0 - z) * (in_1 - z));
 
         // lc_0: (var_in_0 - z) * (var_in_1 - z) = var_mul
-        let lc_0_a = LinearCombination::construct(vec![(var_in_0, Scalar::one())], -z);
-        let lc_0_b = LinearCombination::construct(vec![(var_in_1, Scalar::one())], -z);
+        let lc_0_a = LinearCombination::new(vec![(var_in_0, Scalar::one())], -z);
+        let lc_0_b = LinearCombination::new(vec![(var_in_1, Scalar::one())], -z);
         let lc_0_c =
-            LinearCombination::construct(vec![(var_mul.clone(), Scalar::one())], Scalar::zero());
-        assert!(cs.push_lc(lc_0_a, lc_0_b, lc_0_c).is_ok());
+            LinearCombination::new(vec![(var_mul.clone(), Scalar::one())], Scalar::zero());
+        assert!(cs.constrain(lc_0_a, lc_0_b, lc_0_c).is_ok());
 
         // lc_1: (var_out_0 - z) * (var_out_1 - z) = var_mul
-        let lc_1_a = LinearCombination::construct(vec![(var_out_0, Scalar::one())], -z);
-        let lc_1_b = LinearCombination::construct(vec![(var_out_1, Scalar::one())], -z);
-        let lc_1_c = LinearCombination::construct(vec![(var_mul, Scalar::one())], Scalar::zero());
-        assert!(cs.push_lc(lc_1_a, lc_1_b, lc_1_c).is_ok());
+        let lc_1_a = LinearCombination::new(vec![(var_out_0, Scalar::one())], -z);
+        let lc_1_b = LinearCombination::new(vec![(var_out_1, Scalar::one())], -z);
+        let lc_1_c = LinearCombination::new(vec![(var_mul, Scalar::one())], Scalar::zero());
+        assert!(cs.constrain(lc_1_a, lc_1_b, lc_1_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);
@@ -618,7 +618,7 @@ mod tests {
         let out_1 = cs.alloc_variable(val_out_1);
 
         // lc_a: in_0 * (-1) + in_1 * (-c) + out_0 + out_1 * (c)
-        let lc_a = LinearCombination::construct(
+        let lc_a = LinearCombination::new(
             vec![
                 (in_0.clone(), -Scalar::one()),
                 (in_1.clone(), -c),
@@ -628,7 +628,7 @@ mod tests {
             Scalar::zero(),
         );
         // lc_b: in_0 + in_1 + out_1 * (-1) + out_0 * (c) + t_0 * (-c*c) + t_1 * (c*c)
-        let lc_b = LinearCombination::construct(
+        let lc_b = LinearCombination::new(
             vec![
                 (in_0, Scalar::one()),
                 (in_1, Scalar::one()),
@@ -639,9 +639,9 @@ mod tests {
             ],
             Scalar::zero(),
         );
-        let lc_c = LinearCombination::construct(vec![], Scalar::zero());
+        let lc_c = LinearCombination::new(vec![], Scalar::zero());
 
-        assert!(cs.push_lc(lc_a, lc_b, lc_c).is_ok());
+        assert!(cs.constrain(lc_a, lc_b, lc_c).is_ok());
 
         let (circuit, prover_input, verifier_input) =
             cs.create_proof_input(&pedersen_generators, &mut rng);


### PR DESCRIPTION
Part of r1cs circuit support plan: https://github.com/dalek-cryptography/bulletproofs/issues/118

This PR creates:
- r1cs format
- r1cs -> BP naive transformation
- r1cs circuits (e.g. shuffle and merge/split), and tests that they generate & verify proofs correctly