### PR TITLE
Merge main into circuit

### DIFF
--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -319,6 +319,21 @@ impl CircuitProof {
             .map(|(x_exp, mult)| x_exp * mult * r);
         let T_points = vec![self.T_1, self.T_3, self.T_4, self.T_5, self.T_6];
 
+        // Decompress L and R points from inner product proof
+        let Ls = self
+            .ipp_proof
+            .L_vec
+            .iter()
+            .map(|p| p.decompress().ok_or("RangeProof's L point is invalid"))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let Rs = self
+            .ipp_proof
+            .R_vec
+            .iter()
+            .map(|p| p.decompress().ok_or("RangeProof's R point is invalid"))
+            .collect::<Result<Vec<_>, _>>()?;
+
         let mega_check = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(x) // A_I
                 .chain(iter::once(xx)) // A_O
@@ -344,8 +359,8 @@ impl CircuitProof {
                 .chain(iter::once(&gen.pedersen_generators.B_blinding))
                 .chain(gen.G.iter())
                 .chain(gen.H.iter())
-                .chain(self.ipp_proof.L_vec.iter())
-                .chain(self.ipp_proof.R_vec.iter())
+                .chain(Ls.iter())
+                .chain(Rs.iter())
                 .chain(V.iter())
                 .chain(T_points.iter()),
         );

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -5,16 +5,16 @@
 use std::borrow::Borrow;
 use std::iter;
 
-use curve25519_dalek::ristretto::RistrettoPoint;
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::VartimeMultiscalarMul;
 
 use proof_transcript::ProofTranscript;
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct InnerProductProof {
-    pub(crate) L_vec: Vec<RistrettoPoint>,
-    pub(crate) R_vec: Vec<RistrettoPoint>,
+    pub(crate) L_vec: Vec<CompressedRistretto>,
+    pub(crate) R_vec: Vec<CompressedRistretto>,
     pub(crate) a: Scalar,
     pub(crate) b: Scalar,
 }
@@ -96,8 +96,8 @@ impl InnerProductProof {
                 G_L.iter().chain(H_R.iter()).chain(iter::once(Q)),
             );
 
-            L_vec.push(L);
-            R_vec.push(R);
+            L_vec.push(L.compress());
+            R_vec.push(R.compress());
 
             verifier.commit(L.compress().as_bytes());
             verifier.commit(R.compress().as_bytes());
@@ -139,10 +139,8 @@ impl InnerProductProof {
 
         let mut challenges = Vec::with_capacity(lg_n);
         for (L, R) in self.L_vec.iter().zip(self.R_vec.iter()) {
-            // XXX maybe avoid this compression when proof ser/de is sorted out
-            transcript.commit(L.compress().as_bytes());
-            transcript.commit(R.compress().as_bytes());
-
+            transcript.commit(L.as_bytes());
+            transcript.commit(R.as_bytes());
             challenges.push(transcript.challenge_scalar());
         }
 
@@ -190,7 +188,7 @@ impl InnerProductProof {
         Q: &RistrettoPoint,
         G: &[RistrettoPoint],
         H: &[RistrettoPoint],
-    ) -> Result<(), ()>
+    ) -> Result<(), &'static str>
     where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,
@@ -210,6 +208,18 @@ impl InnerProductProof {
         let neg_u_sq = u_sq.iter().map(|ui| -ui);
         let neg_u_inv_sq = u_inv_sq.iter().map(|ui| -ui);
 
+        let Ls = self
+            .L_vec
+            .iter()
+            .map(|p| p.decompress().ok_or("InnerProductProof L point is invalid"))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let Rs = self
+            .R_vec
+            .iter()
+            .map(|p| p.decompress().ok_or("InnerProductProof R point is invalid"))
+            .collect::<Result<Vec<_>, _>>()?;
+
         let expect_P = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(self.a * self.b)
                 .chain(a_times_s)
@@ -219,15 +229,81 @@ impl InnerProductProof {
             iter::once(Q)
                 .chain(G.iter())
                 .chain(H.iter())
-                .chain(self.L_vec.iter())
-                .chain(self.R_vec.iter()),
+                .chain(Ls.iter())
+                .chain(Rs.iter()),
         );
 
         if expect_P == *P {
             Ok(())
         } else {
-            Err(())
+            Err("InnerProductProof is invalid")
         }
+    }
+
+    /// Returns the size in bytes required to serialize the inner
+    /// product proof.
+    ///
+    /// For vectors of length `n` the proof size is
+    /// \\(32 \cdot (2\lg n+2)\\) bytes.
+    pub fn serialized_size(&self) -> usize {
+        (self.L_vec.len() * 2 + 2) * 32
+    }
+
+    /// Serializes the proof into a byte array of \\(2n+2\\) 32-byte elements.
+    /// The layout of the inner product proof is:
+    /// * \\(n\\) pairs of compressed Ristretto points \\(L_0, R_0 \dots, L_{n-1}, R_{n-1}\\),
+    /// * two scalars \\(a, b\\).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.serialized_size());
+        for (l, r) in self.L_vec.iter().zip(self.R_vec.iter()) {
+            buf.extend_from_slice(l.as_bytes());
+            buf.extend_from_slice(r.as_bytes());
+        }
+        buf.extend_from_slice(self.a.as_bytes());
+        buf.extend_from_slice(self.b.as_bytes());
+        buf
+    }
+
+    /// Deserializes the proof from a byte slice.
+    /// Returns an error in the following cases:
+    /// * the slice does not have \\(2n+2\\) 32-byte elements,
+    /// * \\(n\\) is larger or equal to 32 (proof is too big),
+    /// * any of \\(2n\\) points are not valid compressed Ristretto points,
+    /// * any of 2 scalars are not canonical scalars modulo Ristretto group order.
+    pub fn from_bytes(slice: &[u8]) -> Result<InnerProductProof, &'static str> {
+        let b = slice.len();
+        if b % 32 != 0 {
+            return Err("InnerProductProof size is not divisible by 32");
+        }
+        let num_elements = b / 32;
+        if num_elements < 2 {
+            return Err("InnerProductProof must contain at least two 32-byte elements");
+        }
+        if (num_elements - 2) % 2 != 0 {
+            return Err("InnerProductProof must contain even number of points");
+        }
+        let lg_n = (num_elements - 2) / 2;
+        if lg_n >= 32 {
+            return Err("InnerProductProof contains too many points");
+        }
+
+        use util::read32;
+
+        let mut L_vec: Vec<CompressedRistretto> = Vec::with_capacity(lg_n);
+        let mut R_vec: Vec<CompressedRistretto> = Vec::with_capacity(lg_n);
+        for i in 0..lg_n {
+            let pos = 2 * i * 32;
+            L_vec.push(CompressedRistretto(read32(&slice[pos..])));
+            R_vec.push(CompressedRistretto(read32(&slice[pos + 32..])));
+        }
+
+        let pos = 2 * lg_n * 32;
+        let a = Scalar::from_canonical_bytes(read32(&slice[pos..]))
+            .ok_or("InnerProductProof.a is not a canonical scalar")?;
+        let b = Scalar::from_canonical_bytes(read32(&slice[pos + 32..]))
+            .ok_or("InnerProductProof.b is not a canonical scalar")?;
+
+        Ok(InnerProductProof { L_vec, R_vec, a, b })
     }
 }
 
@@ -299,6 +375,14 @@ mod tests {
             b.clone(),
         );
 
+        let mut verifier = ProofTranscript::new(b"innerproducttest");
+        assert!(
+            proof
+                .verify(&mut verifier, util::exp_iter(y_inv), &P, &Q, &G, &H)
+                .is_ok()
+        );
+
+        let proof = InnerProductProof::from_bytes(proof.to_bytes().as_slice()).unwrap();
         let mut verifier = ProofTranscript::new(b"innerproducttest");
         assert!(
             proof

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
 
 extern crate byteorder;
+extern crate core;
 extern crate curve25519_dalek;
 extern crate rand;
 extern crate sha2;
@@ -17,6 +18,7 @@ extern crate tiny_keccak;
 
 #[macro_use]
 extern crate serde_derive;
+extern crate serde;
 
 #[cfg(test)]
 extern crate test;

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -232,10 +232,10 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
         );
 
         Ok(RangeProof {
-            A: self.A,
-            S: self.S,
-            T_1: self.T_1,
-            T_2: self.T_2,
+            A: self.A.compress(),
+            S: self.S.compress(),
+            T_1: self.T_1.compress(),
+            T_2: self.T_2.compress(),
             t_x,
             t_x_blinding,
             e_blinding,

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -5,7 +5,7 @@ use rand::{CryptoRng, Rng};
 
 use std::iter;
 
-use curve25519_dalek::ristretto::RistrettoPoint;
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
 
@@ -14,6 +14,9 @@ use inner_product_proof::InnerProductProof;
 use proof_transcript::ProofTranscript;
 use util;
 
+use serde::de::Visitor;
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
 // Modules for MPC protocol
 
 pub mod dealer;
@@ -21,16 +24,16 @@ pub mod messages;
 pub mod party;
 
 /// The `RangeProof` struct represents a single range proof.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct RangeProof {
     /// Commitment to the bits of the value
-    A: RistrettoPoint,
+    A: CompressedRistretto,
     /// Commitment to the blinding factors
-    S: RistrettoPoint,
+    S: CompressedRistretto,
     /// Commitment to the \\(t_1\\) coefficient of \\( t(x) \\)
-    T_1: RistrettoPoint,
+    T_1: CompressedRistretto,
     /// Commitment to the \\(t_2\\) coefficient of \\( t(x) \\)
-    T_2: RistrettoPoint,
+    T_2: CompressedRistretto,
     /// Evaluation of the polynomial \\(t(x)\\) at the challenge point \\(x\\)
     t_x: Scalar,
     /// Blinding factor for the synthetic commitment to \\(t(x)\\)
@@ -122,7 +125,7 @@ impl RangeProof {
         transcript: &mut ProofTranscript,
         rng: &mut R,
         n: usize,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
         self.verify(&[*V], gens, transcript, rng, n)
     }
 
@@ -136,7 +139,7 @@ impl RangeProof {
         transcript: &mut ProofTranscript,
         rng: &mut R,
         n: usize,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
         // First, replay the "interactive" protocol using the proof
         // data to recompute all challenges.
 
@@ -145,19 +148,21 @@ impl RangeProof {
         transcript.commit_u64(n as u64);
         transcript.commit_u64(m as u64);
 
+        // TODO: allow user to supply compressed commitments
+        // to avoid unnecessary compression
         for V in value_commitments.iter() {
             transcript.commit(V.compress().as_bytes());
         }
-        transcript.commit(self.A.compress().as_bytes());
-        transcript.commit(self.S.compress().as_bytes());
+        transcript.commit(self.A.as_bytes());
+        transcript.commit(self.S.as_bytes());
 
         let y = transcript.challenge_scalar();
         let z = transcript.challenge_scalar();
         let zz = z * z;
         let minus_z = -z;
 
-        transcript.commit(self.T_1.compress().as_bytes());
-        transcript.commit(self.T_2.compress().as_bytes());
+        transcript.commit(self.T_1.as_bytes());
+        transcript.commit(self.T_2.as_bytes());
 
         let x = transcript.challenge_scalar();
 
@@ -192,6 +197,25 @@ impl RangeProof {
         let value_commitment_scalars = util::exp_iter(z).take(m).map(|z_exp| c * zz * z_exp);
         let basepoint_scalar = w * (self.t_x - a * b) + c * (delta(n, m, &y, &z) - self.t_x);
 
+        let Ls = self
+            .ipp_proof
+            .L_vec
+            .iter()
+            .map(|p| p.decompress().ok_or("RangeProof's L point is invalid"))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let Rs = self
+            .ipp_proof
+            .R_vec
+            .iter()
+            .map(|p| p.decompress().ok_or("RangeProof's R point is invalid"))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let A = self.A.decompress().ok_or("RangeProof A is invalid")?;
+        let S = self.S.decompress().ok_or("RangeProof S is invalid")?;
+        let T_1 = self.T_1.decompress().ok_or("RangeProof T_1 is invalid")?;
+        let T_2 = self.T_2.decompress().ok_or("RangeProof T_2 is invalid")?;
+
         let mega_check = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(Scalar::one())
                 .chain(iter::once(x))
@@ -204,24 +228,124 @@ impl RangeProof {
                 .chain(h)
                 .chain(x_sq.iter().cloned())
                 .chain(x_inv_sq.iter().cloned()),
-            iter::once(&self.A)
-                .chain(iter::once(&self.S))
+            iter::once(&A)
+                .chain(iter::once(&S))
                 .chain(value_commitments.iter())
-                .chain(iter::once(&self.T_1))
-                .chain(iter::once(&self.T_2))
+                .chain(iter::once(&T_1))
+                .chain(iter::once(&T_2))
                 .chain(iter::once(&gens.pedersen_generators.B_blinding))
                 .chain(iter::once(&gens.pedersen_generators.B))
                 .chain(gens.G.iter())
                 .chain(gens.H.iter())
-                .chain(self.ipp_proof.L_vec.iter())
-                .chain(self.ipp_proof.R_vec.iter()),
+                .chain(Ls.iter())
+                .chain(Rs.iter()),
         );
 
         if mega_check.is_identity() {
             Ok(())
         } else {
-            Err(())
+            Err("RangeProof is invalid")
         }
+    }
+
+    /// Serializes the proof into a byte array of \\(2 \lg n + 9\\)
+    /// 32-byte elements, where \\(n\\) is the number of secret bits.
+    ///
+    /// # Layout
+    ///
+    /// The layout of the range proof encoding is:
+    ///
+    /// * four compressed Ristretto points \\(A,S,T_1,T_2\\),
+    /// * three scalars \\(t_x, \tilde{t}_x, \tilde{e}\\),
+    /// * \\(n\\) pairs of compressed Ristretto points \\(L_0,R_0\dots,L_{n-1},R_{n-1}\\),
+    /// * two scalars \\(a, b\\).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        // 7 elements: points A, S, T1, T2, scalars tx, tx_bl, e_bl.
+        let mut buf = Vec::with_capacity(7 * 32 + self.ipp_proof.serialized_size());
+        buf.extend_from_slice(self.A.as_bytes());
+        buf.extend_from_slice(self.S.as_bytes());
+        buf.extend_from_slice(self.T_1.as_bytes());
+        buf.extend_from_slice(self.T_2.as_bytes());
+        buf.extend_from_slice(self.t_x.as_bytes());
+        buf.extend_from_slice(self.t_x_blinding.as_bytes());
+        buf.extend_from_slice(self.e_blinding.as_bytes());
+        // XXX this costs an extra alloc
+        buf.extend_from_slice(self.ipp_proof.to_bytes().as_slice());
+        buf
+    }
+
+    /// Deserializes the proof from a byte slice.
+    ///
+    /// Returns an error if the byte slice cannot be parsed into a `RangeProof`.
+    pub fn from_bytes(slice: &[u8]) -> Result<RangeProof, &'static str> {
+        if slice.len() % 32 != 0 {
+            return Err("RangeProof size is not divisible by 32");
+        }
+        if slice.len() < 7 * 32 {
+            return Err("RangeProof size is too small");
+        }
+
+        use util::read32;
+
+        let A = CompressedRistretto(read32(&slice[0 * 32..]));
+        let S = CompressedRistretto(read32(&slice[1 * 32..]));
+        let T_1 = CompressedRistretto(read32(&slice[2 * 32..]));
+        let T_2 = CompressedRistretto(read32(&slice[3 * 32..]));
+
+        let t_x = Scalar::from_canonical_bytes(read32(&slice[4 * 32..]))
+            .ok_or("RangeProof.t_x is not a canonical scalar")?;
+        let t_x_blinding = Scalar::from_canonical_bytes(read32(&slice[5 * 32..]))
+            .ok_or("RangeProof.t_x_blinding is not a canonical scalar")?;
+        let e_blinding = Scalar::from_canonical_bytes(read32(&slice[6 * 32..]))
+            .ok_or("RangeProof.e_blinding is not a canonical scalar")?;
+
+        let ipp_proof = InnerProductProof::from_bytes(&slice[7 * 32..])?;
+
+        Ok(RangeProof {
+            A,
+            S,
+            T_1,
+            T_2,
+            t_x,
+            t_x_blinding,
+            e_blinding,
+            ipp_proof,
+        })
+    }
+}
+
+impl Serialize for RangeProof {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.to_bytes()[..])
+    }
+}
+
+impl<'de> Deserialize<'de> for RangeProof {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RangeProofVisitor;
+
+        impl<'de> Visitor<'de> for RangeProofVisitor {
+            type Value = RangeProof;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("a valid RangeProof")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<RangeProof, E>
+            where
+                E: serde::de::Error,
+            {
+                RangeProof::from_bytes(v).map_err(|e| serde::de::Error::custom(e))
+            }
+        }
+
+        deserializer.deserialize_bytes(RangeProofVisitor)
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -199,6 +199,13 @@ fn sum_of_powers_slow(x: &Scalar, n: usize) -> Scalar {
     exp_iter(*x).take(n).sum()
 }
 
+/// Given `data` with `len >= 32`, return the first 32 bytes.
+pub fn read32(data: &[u8]) -> [u8; 32] {
+    let mut buf32 = [0u8; 32];
+    buf32[..].copy_from_slice(&data[..32]);
+    buf32
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This pulls in the changes to use compressed points in the rangeproofs and inner product proofs.

The current circuit proof code stores the points in the circuit proof in uncompressed format, which is now inconsistent with the range proof code.  Maybe this PR should also change the circuit proofs to use compressed points?