### PR TITLE
Enforce lengths of inputs to circuit proofs

### DIFF
--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -72,6 +72,8 @@ pub struct CircuitProof {
 }
 
 impl CircuitProof {
+    /// Create a circuit proof.
+    /// `circuit.n` must be either 0 or a power of 2, for the inner product proof to work.
     pub fn prove<R: Rng + CryptoRng>(
         gen: &Generators,
         transcript: &mut ProofTranscript,
@@ -92,6 +94,9 @@ impl CircuitProof {
         }
         if gen.n != circuit.n {
             return Err("Generator length doesn't match specified parameters.");
+        }
+        if !(circuit.n.is_power_of_two() || circuit.n == 0) {
+            return Err("Circuit's n parameter must be either 0 or a power of 2.");
         }
 
         transcript.commit_u64(circuit.n as u64);

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -28,9 +28,6 @@ impl InnerProductProof {
     /// The `verifier` is passed in as a parameter so that the
     /// challenges depend on the *entire* transcript (including parent
     /// protocols).
-    ///
-    /// The lengths of the vectors must all be the same, and must all be
-    /// either 0 or a power of 2.
     pub fn create<I>(
         verifier: &mut ProofTranscript,
         Q: &RistrettoPoint,
@@ -68,9 +65,6 @@ impl InnerProductProof {
         assert_eq!(H.len(), n);
         assert_eq!(a.len(), n);
         assert_eq!(b.len(), n);
-
-        // All of the input vectors must have a length that is a power of two.
-        assert!(n.is_power_of_two());
 
         // XXX save these scalar mults by unrolling them into the
         // first iteration of the loop below

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -28,6 +28,9 @@ impl InnerProductProof {
     /// The `verifier` is passed in as a parameter so that the
     /// challenges depend on the *entire* transcript (including parent
     /// protocols).
+    ///
+    /// The lengths of the vectors must all be the same, and must all be
+    /// either 0 or a power of 2.
     pub fn create<I>(
         verifier: &mut ProofTranscript,
         Q: &RistrettoPoint,
@@ -65,6 +68,9 @@ impl InnerProductProof {
         assert_eq!(H.len(), n);
         assert_eq!(a.len(), n);
         assert_eq!(b.len(), n);
+
+        // All of the input vectors must have a length that is a power of two.
+        assert!(n.is_power_of_two());
 
         // XXX save these scalar mults by unrolling them into the
         // first iteration of the loop below


### PR DESCRIPTION
`circuit.n` for circuits must be either 0 or a power of 2.
It is the responsibility of any circuit creators (e.g. `r1cs` module) to create circuits where `circuit.n` is a power of 2.
Discussed here: https://github.com/dalek-cryptography/bulletproofs/issues/107