### PR TITLE
Enforce that `n` is 0 or power of 2 for IPP

### DIFF
--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -28,6 +28,9 @@ impl InnerProductProof {
     /// The `verifier` is passed in as a parameter so that the
     /// challenges depend on the *entire* transcript (including parent
     /// protocols).
+    ///
+    /// The lengths of the vectors must all be the same, and must all be
+    /// either 0 or a power of 2.
     pub fn create<I>(
         verifier: &mut ProofTranscript,
         Q: &RistrettoPoint,
@@ -56,6 +59,9 @@ impl InnerProductProof {
         assert_eq!(H.len(), n);
         assert_eq!(a.len(), n);
         assert_eq!(b.len(), n);
+
+        // All of the input vectors must have a length that is a power of two.
+        assert!(n.is_power_of_two());
 
         // XXX save these scalar mults by unrolling them into the
         // first iteration of the loop below


### PR DESCRIPTION
Discussed here:
https://github.com/dalek-cryptography/bulletproofs/issues/107

IPP only works with power-of-two inputs, unless exceptions are specially programmed (e.g. length 0 inputs in when working with circuits). Add a check that the IPP inputs are meeting this requirement.