### PR TITLE
Pad circuits when creating them from `r1cs` format

### DIFF
--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -34,6 +34,13 @@ impl LinearCombination {
         }
     }
 
+    pub fn zero() -> Self {
+        LinearCombination {
+            variables: vec![],
+            constant: Scalar::zero(),
+        }
+    }
+
     pub fn get_variables(&self) -> Vec<(Variable, Scalar)> {
         self.variables.clone()
     }
@@ -177,19 +184,10 @@ impl ConstraintSystem {
         // If `n`, the number of multiplications, is not 0 or 2, then pad the circuit.
         let n = self.a.len();
         if !(n == 0 || n.is_power_of_two()) {
-            let pad_length = n.next_power_of_two() - n;
-            self.a.append(&mut vec![
-                LinearCombination::new(vec![], Scalar::zero());
-                pad_length
-            ]);
-            self.b.append(&mut vec![
-                LinearCombination::new(vec![], Scalar::zero());
-                pad_length
-            ]);
-            self.c.append(&mut vec![
-                LinearCombination::new(vec![], Scalar::zero());
-                pad_length
-            ]);
+            let pad = n.next_power_of_two() - n;
+            self.a.append(&mut vec![LinearCombination::zero(); pad]);
+            self.b.append(&mut vec![LinearCombination::zero(); pad]);
+            self.c.append(&mut vec![LinearCombination::zero(); pad]);
         }
 
         let m = self.var_assignment.len();


### PR DESCRIPTION
Makes sure r1cs → bp conversion pads circuits if `n` is not 0 or a power of 2.
A follow-up to PR https://github.com/dalek-cryptography/bulletproofs/pull/120 which enforces that inputs to circuit proofs must have `n` be 0 or a power of 2.

Discussed in this issue: https://github.com/dalek-cryptography/bulletproofs/issues/118