### PR TITLE
Add failure-based error types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ byteorder = "1.2.1"
 serde = "1"
 serde_derive = "1"
 tiny-keccak = "1.4.1"
+failure = "0.1"
 
 [dev-dependencies]
 hex = "^0.3"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,87 @@
+//! Errors related to proving and verifying proofs.
+
+/// Represents an error in proof creation, verification, or parsing.
+#[derive(Fail, Clone, Debug, Eq, PartialEq)]
+pub enum ProofError {
+    /// This error occurs when a proof failed to verify.
+    #[fail(display = "Proof verification failed.")]
+    VerificationError,
+    /// This error occurs when the proof encoding is malformed.
+    #[fail(display = "Proof data could not be parsed.")]
+    FormatError,
+    /// This error occurs during proving if the number of blinding
+    /// factors does not match the number of values.
+    #[fail(display = "Wrong number of blinding factors supplied.")]
+    WrongNumBlindingFactors,
+    /// This error occurs when attempting to create a proof with
+    /// bitsize other than \\(8\\), \\(16\\), \\(32\\), or \\(64\\).
+    #[fail(display = "Invalid bitsize, must have n = 8,16,32,64")]
+    InvalidBitsize,
+    /// This error occurs when attempting to create an aggregated
+    /// proof with non-power-of-two aggregation size.
+    #[fail(display = "Invalid aggregation size, m must be a power of 2")]
+    InvalidAggregation,
+    /// This error results from an internal error during proving.
+    ///
+    /// The single-party prover is implemented by performing
+    /// multiparty computation with ourselves.  However, because the
+    /// MPC protocol is not exposed by the single-party API, we
+    /// consider its errors to be internal errors.
+    #[fail(display = "Internal error during proof creation: {}", _0)]
+    ProvingError(MPCError),
+}
+
+impl From<MPCError> for ProofError {
+    fn from(e: MPCError) -> ProofError {
+        match e {
+            MPCError::InvalidBitsize => ProofError::InvalidBitsize,
+            MPCError::InvalidAggregation => ProofError::InvalidAggregation,
+            _ => ProofError::ProvingError(e),
+        }
+    }
+}
+
+/// Represents an error during the multiparty computation protocol for
+/// proof aggregation.
+///
+/// This is a separate type from the `ProofError` to allow a layered
+/// API: although the MPC protocol is used internally for single-party
+/// proving, its API should not expose the complexity of the MPC
+/// protocol.
+#[derive(Fail, Clone, Debug, Eq, PartialEq)]
+pub enum MPCError {
+    /// This error occurs when the dealer gives a zero challenge,
+    /// which would annihilate the blinding factors.
+    #[fail(display = "Dealer gave a malicious challenge value.")]
+    MaliciousDealer,
+    /// This error occurs when attempting to create a proof with
+    /// bitsize other than \\(8\\), \\(16\\), \\(32\\), or \\(64\\).
+    #[fail(display = "Invalid bitsize, must have n = 8,16,32,64")]
+    InvalidBitsize,
+    /// This error occurs when attempting to create an aggregated
+    /// proof with non-power-of-two aggregation size.
+    #[fail(display = "Invalid aggregation size, m must be a power of 2")]
+    InvalidAggregation,
+    /// This error occurs when the dealer is given the wrong number of
+    /// value commitments.
+    #[fail(display = "Wrong number of value commitments")]
+    WrongNumValueCommitments,
+    /// This error occurs when the dealer is given the wrong number of
+    /// polynomial commitments.
+    #[fail(display = "Wrong number of value commitments")]
+    WrongNumPolyCommitments,
+    /// This error occurs when the dealer is given the wrong number of
+    /// proof shares.
+    #[fail(display = "Wrong number of proof shares")]
+    WrongNumProofShares,
+    /// This error occurs when one or more parties submit malformed
+    /// proof shares.
+    #[fail(
+        display = "Malformed proof shares from parties {:?}",
+        bad_shares
+    )]
+    MalformedProofShares {
+        /// A vector with the indexes of the parties whose shares were malformed.
+        bad_shares: Vec<usize>,
+    },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,36 +11,39 @@
 extern crate byteorder;
 extern crate core;
 extern crate curve25519_dalek;
+#[macro_use]
+extern crate failure;
 extern crate rand;
 extern crate sha2;
 extern crate subtle;
 extern crate tiny_keccak;
-
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
 
 #[cfg(test)]
-extern crate test;
-
-#[cfg(test)]
 extern crate bincode;
+#[cfg(test)]
+extern crate test;
 
 mod util;
 
 #[doc(include = "../docs/notes.md")]
 mod notes {}
+mod errors;
 mod generators;
 mod inner_product_proof;
 mod proof_transcript;
 mod range_proof;
 
+pub use errors::ProofError;
 pub use generators::{Generators, GeneratorsView, PedersenGenerators};
 pub use proof_transcript::ProofTranscript;
 pub use range_proof::RangeProof;
 
 #[doc(include = "../docs/aggregation-api.md")]
 pub mod aggregation {
+    pub use errors::MPCError;
     pub use range_proof::dealer;
     pub use range_proof::messages;
     pub use range_proof::party;

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -55,7 +55,7 @@ impl ProofShare {
         value_challenge: &ValueChallenge,
         poly_commitment: &PolyCommitment,
         poly_challenge: &PolyChallenge,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), ()> {
         use std::iter;
 
         use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
@@ -76,7 +76,7 @@ impl ProofShare {
         let y_inv = y.invert(); // y^(-1)
 
         if self.t_x != inner_product(&self.l_vec, &self.r_vec) {
-            return Err("Inner product of l_vec and r_vec is not equal to t_x");
+            return Err(());
         }
 
         let g = self.l_vec.iter().map(|l_i| minus_z - l_i);
@@ -102,7 +102,7 @@ impl ProofShare {
                 .chain(gens.share(j).H.iter()),
         );
         if !P_check.is_identity() {
-            return Err("P check is not equal to zero");
+            return Err(());
         }
 
         let sum_of_powers_y = util::sum_of_powers(&y, n);
@@ -120,10 +120,11 @@ impl ProofShare {
                 .chain(iter::once(&gens.pedersen_generators.B))
                 .chain(iter::once(&gens.pedersen_generators.B_blinding)),
         );
-        if !t_check.is_identity() {
-            return Err("t check is not equal to zero");
-        }
 
-        Ok(())
+        if t_check.is_identity() {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 }


### PR DESCRIPTION
Closes #70.

The errors are split into two types, corresponding to each level of the range proof API.