### PR TITLE
Merge RP error-handling into the circuit branch.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ byteorder = "1.2.1"
 serde = "1"
 serde_derive = "1"
 tiny-keccak = "1.4.1"
+failure = "0.1"
 
 [dev-dependencies]
 hex = "^0.3"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,87 @@
+//! Errors related to proving and verifying proofs.
+
+/// Represents an error in proof creation, verification, or parsing.
+#[derive(Fail, Clone, Debug, Eq, PartialEq)]
+pub enum ProofError {
+    /// This error occurs when a proof failed to verify.
+    #[fail(display = "Proof verification failed.")]
+    VerificationError,
+    /// This error occurs when the proof encoding is malformed.
+    #[fail(display = "Proof data could not be parsed.")]
+    FormatError,
+    /// This error occurs during proving if the number of blinding
+    /// factors does not match the number of values.
+    #[fail(display = "Wrong number of blinding factors supplied.")]
+    WrongNumBlindingFactors,
+    /// This error occurs when attempting to create a proof with
+    /// bitsize other than \\(8\\), \\(16\\), \\(32\\), or \\(64\\).
+    #[fail(display = "Invalid bitsize, must have n = 8,16,32,64")]
+    InvalidBitsize,
+    /// This error occurs when attempting to create an aggregated
+    /// proof with non-power-of-two aggregation size.
+    #[fail(display = "Invalid aggregation size, m must be a power of 2")]
+    InvalidAggregation,
+    /// This error results from an internal error during proving.
+    ///
+    /// The single-party prover is implemented by performing
+    /// multiparty computation with ourselves.  However, because the
+    /// MPC protocol is not exposed by the single-party API, we
+    /// consider its errors to be internal errors.
+    #[fail(display = "Internal error during proof creation: {}", _0)]
+    ProvingError(MPCError),
+}
+
+impl From<MPCError> for ProofError {
+    fn from(e: MPCError) -> ProofError {
+        match e {
+            MPCError::InvalidBitsize => ProofError::InvalidBitsize,
+            MPCError::InvalidAggregation => ProofError::InvalidAggregation,
+            _ => ProofError::ProvingError(e),
+        }
+    }
+}
+
+/// Represents an error during the multiparty computation protocol for
+/// proof aggregation.
+///
+/// This is a separate type from the `ProofError` to allow a layered
+/// API: although the MPC protocol is used internally for single-party
+/// proving, its API should not expose the complexity of the MPC
+/// protocol.
+#[derive(Fail, Clone, Debug, Eq, PartialEq)]
+pub enum MPCError {
+    /// This error occurs when the dealer gives a zero challenge,
+    /// which would annihilate the blinding factors.
+    #[fail(display = "Dealer gave a malicious challenge value.")]
+    MaliciousDealer,
+    /// This error occurs when attempting to create a proof with
+    /// bitsize other than \\(8\\), \\(16\\), \\(32\\), or \\(64\\).
+    #[fail(display = "Invalid bitsize, must have n = 8,16,32,64")]
+    InvalidBitsize,
+    /// This error occurs when attempting to create an aggregated
+    /// proof with non-power-of-two aggregation size.
+    #[fail(display = "Invalid aggregation size, m must be a power of 2")]
+    InvalidAggregation,
+    /// This error occurs when the dealer is given the wrong number of
+    /// value commitments.
+    #[fail(display = "Wrong number of value commitments")]
+    WrongNumValueCommitments,
+    /// This error occurs when the dealer is given the wrong number of
+    /// polynomial commitments.
+    #[fail(display = "Wrong number of value commitments")]
+    WrongNumPolyCommitments,
+    /// This error occurs when the dealer is given the wrong number of
+    /// proof shares.
+    #[fail(display = "Wrong number of proof shares")]
+    WrongNumProofShares,
+    /// This error occurs when one or more parties submit malformed
+    /// proof shares.
+    #[fail(
+        display = "Malformed proof shares from parties {:?}",
+        bad_shares
+    )]
+    MalformedProofShares {
+        /// A vector with the indexes of the parties whose shares were malformed.
+        bad_shares: Vec<usize>,
+    },
+}

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -11,6 +11,8 @@ use curve25519_dalek::traits::VartimeMultiscalarMul;
 
 use proof_transcript::ProofTranscript;
 
+use errors::ProofError;
+
 #[derive(Clone, Debug)]
 pub struct InnerProductProof {
     pub(crate) L_vec: Vec<CompressedRistretto>,
@@ -194,7 +196,7 @@ impl InnerProductProof {
         Q: &RistrettoPoint,
         G: &[RistrettoPoint],
         H: &[RistrettoPoint],
-    ) -> Result<(), &'static str>
+    ) -> Result<(), ProofError>
     where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,
@@ -217,13 +219,13 @@ impl InnerProductProof {
         let Ls = self
             .L_vec
             .iter()
-            .map(|p| p.decompress().ok_or("InnerProductProof L point is invalid"))
+            .map(|p| p.decompress().ok_or(ProofError::VerificationError))
             .collect::<Result<Vec<_>, _>>()?;
 
         let Rs = self
             .R_vec
             .iter()
-            .map(|p| p.decompress().ok_or("InnerProductProof R point is invalid"))
+            .map(|p| p.decompress().ok_or(ProofError::VerificationError))
             .collect::<Result<Vec<_>, _>>()?;
 
         let expect_P = RistrettoPoint::vartime_multiscalar_mul(
@@ -242,7 +244,7 @@ impl InnerProductProof {
         if expect_P == *P {
             Ok(())
         } else {
-            Err("InnerProductProof is invalid")
+            Err(ProofError::VerificationError)
         }
     }
 
@@ -276,21 +278,21 @@ impl InnerProductProof {
     /// * \\(n\\) is larger or equal to 32 (proof is too big),
     /// * any of \\(2n\\) points are not valid compressed Ristretto points,
     /// * any of 2 scalars are not canonical scalars modulo Ristretto group order.
-    pub fn from_bytes(slice: &[u8]) -> Result<InnerProductProof, &'static str> {
+    pub fn from_bytes(slice: &[u8]) -> Result<InnerProductProof, ProofError> {
         let b = slice.len();
         if b % 32 != 0 {
-            return Err("InnerProductProof size is not divisible by 32");
+            return Err(ProofError::FormatError);
         }
         let num_elements = b / 32;
         if num_elements < 2 {
-            return Err("InnerProductProof must contain at least two 32-byte elements");
+            return Err(ProofError::FormatError);
         }
         if (num_elements - 2) % 2 != 0 {
-            return Err("InnerProductProof must contain even number of points");
+            return Err(ProofError::FormatError);
         }
         let lg_n = (num_elements - 2) / 2;
         if lg_n >= 32 {
-            return Err("InnerProductProof contains too many points");
+            return Err(ProofError::FormatError);
         }
 
         use util::read32;
@@ -304,10 +306,9 @@ impl InnerProductProof {
         }
 
         let pos = 2 * lg_n * 32;
-        let a = Scalar::from_canonical_bytes(read32(&slice[pos..]))
-            .ok_or("InnerProductProof.a is not a canonical scalar")?;
+        let a = Scalar::from_canonical_bytes(read32(&slice[pos..])).ok_or(ProofError::FormatError)?;
         let b = Scalar::from_canonical_bytes(read32(&slice[pos + 32..]))
-            .ok_or("InnerProductProof.b is not a canonical scalar")?;
+            .ok_or(ProofError::FormatError)?;
 
         Ok(InnerProductProof { L_vec, R_vec, a, b })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 extern crate byteorder;
 extern crate core;
 extern crate curve25519_dalek;
+#[macro_use]
+extern crate failure;
 extern crate rand;
 extern crate sha2;
 extern crate subtle;
@@ -21,27 +23,29 @@ extern crate serde_derive;
 extern crate serde;
 
 #[cfg(test)]
-extern crate test;
-
-#[cfg(test)]
 extern crate bincode;
+#[cfg(test)]
+extern crate test;
 
 mod util;
 
 #[doc(include = "../docs/notes.md")]
 mod notes {}
 mod circuit_proof;
+mod errors;
 mod generators;
 mod inner_product_proof;
 mod proof_transcript;
 mod range_proof;
 
+pub use errors::ProofError;
 pub use generators::{Generators, GeneratorsView, PedersenGenerators};
 pub use proof_transcript::ProofTranscript;
 pub use range_proof::RangeProof;
 
 #[doc(include = "../docs/aggregation-api.md")]
 pub mod aggregation {
+    pub use errors::MPCError;
     pub use range_proof::dealer;
     pub use range_proof::messages;
     pub use range_proof::party;

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -55,7 +55,7 @@ impl ProofShare {
         value_challenge: &ValueChallenge,
         poly_commitment: &PolyCommitment,
         poly_challenge: &PolyChallenge,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), ()> {
         use std::iter;
 
         use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
@@ -76,7 +76,7 @@ impl ProofShare {
         let y_inv = y.invert(); // y^(-1)
 
         if self.t_x != inner_product(&self.l_vec, &self.r_vec) {
-            return Err("Inner product of l_vec and r_vec is not equal to t_x");
+            return Err(());
         }
 
         let g = self.l_vec.iter().map(|l_i| minus_z - l_i);
@@ -102,7 +102,7 @@ impl ProofShare {
                 .chain(gens.share(j).H.iter()),
         );
         if !P_check.is_identity() {
-            return Err("P check is not equal to zero");
+            return Err(());
         }
 
         let sum_of_powers_y = util::sum_of_powers(&y, n);
@@ -120,10 +120,11 @@ impl ProofShare {
                 .chain(iter::once(&gens.pedersen_generators.B))
                 .chain(iter::once(&gens.pedersen_generators.B_blinding)),
         );
-        if !t_check.is_identity() {
-            return Err("t check is not equal to zero");
-        }
 
-        Ok(())
+        if t_check.is_identity() {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 }


### PR DESCRIPTION
This doesn't change the circuit code to use error types (it leaves them as `&'static str` errors) because the circuit code is still in flux and I think that some of the possible errors could disappear if we changed the circuit code.