### PR TITLE
Update to dalek 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["cryptography", "ristretto", "zero-knowledge", "bulletproofs"]
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
-curve25519-dalek = { version = "0.18", features = ["serde"] }
-subtle = "0.6"
+curve25519-dalek = { version = "0.19", features = ["serde"] }
+subtle = "0.7"
 sha2 = "^0.7"
 rand = "0.5.0-pre.2"
 byteorder = "1.2.1"

--- a/benches/bulletproofs.rs
+++ b/benches/bulletproofs.rs
@@ -91,7 +91,7 @@ fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
             let value_commitments: Vec<_> = values
                 .iter()
                 .zip(blindings.iter())
-                .map(|(&v, &v_blinding)| pg.commit(Scalar::from_u64(v), v_blinding))
+                .map(|(&v, &v_blinding)| pg.commit(Scalar::from(v), v_blinding))
                 .collect();
 
             b.iter(|| {

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -417,17 +417,17 @@ mod tests {
     #[test]
     fn test_inner_product() {
         let a = vec![
-            Scalar::from_u64(1),
-            Scalar::from_u64(2),
-            Scalar::from_u64(3),
-            Scalar::from_u64(4),
+            Scalar::from(1u64),
+            Scalar::from(2u64),
+            Scalar::from(3u64),
+            Scalar::from(4u64),
         ];
         let b = vec![
-            Scalar::from_u64(2),
-            Scalar::from_u64(3),
-            Scalar::from_u64(4),
-            Scalar::from_u64(5),
+            Scalar::from(2u64),
+            Scalar::from(3u64),
+            Scalar::from(4u64),
+            Scalar::from(5u64),
         ];
-        assert_eq!(Scalar::from_u64(40), inner_product(&a, &b));
+        assert_eq!(Scalar::from(40u64), inner_product(&a, &b));
     }
 }

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -83,7 +83,7 @@ impl ProofShare {
         let h = self
             .r_vec
             .iter()
-            .zip(util::exp_iter(Scalar::from_u64(2)))
+            .zip(util::exp_iter(Scalar::from(2u64)))
             .zip(util::exp_iter(y_inv))
             .map(|((r_i, exp_2), exp_y_inv)| {
                 z + exp_y_inv * y_jn_inv * (-r_i) + exp_y_inv * y_jn_inv * (zz * z_j * exp_2)
@@ -106,7 +106,7 @@ impl ProofShare {
         }
 
         let sum_of_powers_y = util::sum_of_powers(&y, n);
-        let sum_of_powers_2 = util::sum_of_powers(&Scalar::from_u64(2), n);
+        let sum_of_powers_2 = util::sum_of_powers(&Scalar::from(2u64), n);
         let delta = (z - zz) * sum_of_powers_y * y_jn - z * zz * sum_of_powers_2 * z_j;
         let t_check = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(zz * z_j)

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -186,7 +186,7 @@ impl RangeProof {
 
         // Construct concat_z_and_2, an iterator of the values of
         // z^0 * \vec(2)^n || z^1 * \vec(2)^n || ... || z^(m-1) * \vec(2)^n
-        let powers_of_2: Vec<Scalar> = util::exp_iter(Scalar::from_u64(2)).take(n).collect();
+        let powers_of_2: Vec<Scalar> = util::exp_iter(Scalar::from(2u64)).take(n).collect();
         let powers_of_z = util::exp_iter(z).take(m);
         let concat_z_and_2 =
             powers_of_z.flat_map(|exp_z| powers_of_2.iter().map(move |exp_2| exp_2 * exp_z));
@@ -358,7 +358,7 @@ impl<'de> Deserialize<'de> for RangeProof {
 /// \\]
 fn delta(n: usize, m: usize, y: &Scalar, z: &Scalar) -> Scalar {
     let sum_y = util::sum_of_powers(y, n * m);
-    let sum_2 = util::sum_of_powers(&Scalar::from_u64(2), n);
+    let sum_2 = util::sum_of_powers(&Scalar::from(2u64), n);
     let sum_z = util::sum_of_powers(z, m);
 
     (z - z * z) * sum_y - z * z * z * sum_2 * sum_z
@@ -446,7 +446,7 @@ mod tests {
             value_commitments = values
                 .iter()
                 .zip(blindings.iter())
-                .map(|(&v, &v_blinding)| pg.commit(Scalar::from_u64(v), v_blinding))
+                .map(|(&v, &v_blinding)| pg.commit(Scalar::from(v), v_blinding))
                 .collect();
         }
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -187,14 +187,15 @@ impl RangeProof {
         // Construct concat_z_and_2, an iterator of the values of
         // z^0 * \vec(2)^n || z^1 * \vec(2)^n || ... || z^(m-1) * \vec(2)^n
         let powers_of_2: Vec<Scalar> = util::exp_iter(Scalar::from(2u64)).take(n).collect();
-        let powers_of_z = util::exp_iter(z).take(m);
-        let concat_z_and_2 =
-            powers_of_z.flat_map(|exp_z| powers_of_2.iter().map(move |exp_2| exp_2 * exp_z));
+        let concat_z_and_2: Vec<Scalar> = util::exp_iter(z)
+            .take(m)
+            .flat_map(|exp_z| powers_of_2.iter().map(move |exp_2| exp_2 * exp_z))
+            .collect();
 
         let g = s.iter().map(|s_i| minus_z - a * s_i);
         let h = s_inv
             .zip(util::exp_iter(y.invert()))
-            .zip(concat_z_and_2)
+            .zip(concat_z_and_2.iter())
             .map(|((s_i_inv, exp_y_inv), z_and_2)| z + exp_y_inv * (zz * z_and_2 - b * s_i_inv));
 
         let value_commitment_scalars = util::exp_iter(z).take(m).map(|z_exp| c * zz * z_exp);

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -32,7 +32,7 @@ impl Party {
 
         let V = generators
             .pedersen_generators
-            .commit(Scalar::from_u64(v), v_blinding);
+            .commit(Scalar::from(v), v_blinding);
 
         Ok(PartyAwaitingPosition {
             generators,
@@ -144,7 +144,7 @@ impl<'a> PartyAwaitingValueChallenge<'a> {
         let mut exp_y = offset_y; // start at y^j
         let mut exp_2 = Scalar::one(); // start at 2^0 = 1
         for i in 0..n {
-            let a_L_i = Scalar::from_u64((self.v >> i) & 1);
+            let a_L_i = Scalar::from((self.v >> i) & 1);
             let a_R_i = a_L_i - Scalar::one();
 
             l_poly.0[i] = a_L_i - vc.z;

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,6 +26,10 @@ impl Iterator for ScalarExp {
         self.next_exp_x *= self.x;
         Some(exp_x)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (usize::max_value(), None)
+    }
 }
 
 /// Return an iterator of the powers of `x`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -109,7 +109,7 @@ pub fn sum_of_powers(x: &Scalar, n: usize) -> Scalar {
         return sum_of_powers_slow(x, n);
     }
     if n == 0 || n == 1 {
-        return Scalar::from_u64(n as u64);
+        return Scalar::from(n as u64);
     }
     let mut m = n;
     let mut result = Scalar::one() + x;
@@ -140,29 +140,29 @@ mod tests {
 
     #[test]
     fn exp_2_is_powers_of_2() {
-        let exp_2: Vec<_> = exp_iter(Scalar::from_u64(2)).take(4).collect();
+        let exp_2: Vec<_> = exp_iter(Scalar::from(2u64)).take(4).collect();
 
-        assert_eq!(exp_2[0], Scalar::from_u64(1));
-        assert_eq!(exp_2[1], Scalar::from_u64(2));
-        assert_eq!(exp_2[2], Scalar::from_u64(4));
-        assert_eq!(exp_2[3], Scalar::from_u64(8));
+        assert_eq!(exp_2[0], Scalar::from(1u64));
+        assert_eq!(exp_2[1], Scalar::from(2u64));
+        assert_eq!(exp_2[2], Scalar::from(4u64));
+        assert_eq!(exp_2[3], Scalar::from(8u64));
     }
 
     #[test]
     fn test_inner_product() {
         let a = vec![
-            Scalar::from_u64(1),
-            Scalar::from_u64(2),
-            Scalar::from_u64(3),
-            Scalar::from_u64(4),
+            Scalar::from(1u64),
+            Scalar::from(2u64),
+            Scalar::from(3u64),
+            Scalar::from(4u64),
         ];
         let b = vec![
-            Scalar::from_u64(2),
-            Scalar::from_u64(3),
-            Scalar::from_u64(4),
-            Scalar::from_u64(5),
+            Scalar::from(2u64),
+            Scalar::from(3u64),
+            Scalar::from(4u64),
+            Scalar::from(5u64),
         ];
-        assert_eq!(Scalar::from_u64(40), inner_product(&a, &b));
+        assert_eq!(Scalar::from(40u64), inner_product(&a, &b));
     }
 
     /// Raises `x` to the power `n`.
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_sum_of_powers() {
-        let x = Scalar::from_u64(10);
+        let x = Scalar::from(10u64);
         assert_eq!(sum_of_powers_slow(&x, 0), sum_of_powers(&x, 0));
         assert_eq!(sum_of_powers_slow(&x, 1), sum_of_powers(&x, 1));
         assert_eq!(sum_of_powers_slow(&x, 2), sum_of_powers(&x, 2));
@@ -207,13 +207,13 @@ mod tests {
 
     #[test]
     fn test_sum_of_powers_slow() {
-        let x = Scalar::from_u64(10);
+        let x = Scalar::from(10u64);
         assert_eq!(sum_of_powers_slow(&x, 0), Scalar::zero());
         assert_eq!(sum_of_powers_slow(&x, 1), Scalar::one());
-        assert_eq!(sum_of_powers_slow(&x, 2), Scalar::from_u64(11));
-        assert_eq!(sum_of_powers_slow(&x, 3), Scalar::from_u64(111));
-        assert_eq!(sum_of_powers_slow(&x, 4), Scalar::from_u64(1111));
-        assert_eq!(sum_of_powers_slow(&x, 5), Scalar::from_u64(11111));
-        assert_eq!(sum_of_powers_slow(&x, 6), Scalar::from_u64(111111));
+        assert_eq!(sum_of_powers_slow(&x, 2), Scalar::from(11u64));
+        assert_eq!(sum_of_powers_slow(&x, 3), Scalar::from(111u64));
+        assert_eq!(sum_of_powers_slow(&x, 4), Scalar::from(1111u64));
+        assert_eq!(sum_of_powers_slow(&x, 5), Scalar::from(11111u64));
+        assert_eq!(sum_of_powers_slow(&x, 6), Scalar::from(111111u64));
     }
 }


### PR DESCRIPTION
This allows using the fallible multiscalar API with inline point decompression.

We also have to do an extra `.collect()` of some scalars, so that the iterators of scalars we feed into the MSM function have known lengths. This is because the upstream behaviour changed to enforce that the input iterators must have known lengths, preventing bugs like the ones @cathieyun was hitting.