### PR TITLE
Check generator lengths in range proof

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,11 +15,11 @@ pub enum ProofError {
     WrongNumBlindingFactors,
     /// This error occurs when attempting to create a proof with
     /// bitsize other than \\(8\\), \\(16\\), \\(32\\), or \\(64\\).
-    #[fail(display = "Invalid bitsize, must have n = 8,16,32,64")]
+    #[fail(display = "Invalid bitsize, must have n = 8,16,32,64.")]
     InvalidBitsize,
     /// This error occurs when attempting to create an aggregated
     /// proof with non-power-of-two aggregation size.
-    #[fail(display = "Invalid aggregation size, m must be a power of 2")]
+    #[fail(display = "Invalid aggregation size, m must be a power of 2.")]
     InvalidAggregation,
     /// This error occurs when the generators are of the wrong length.
     #[fail(display = "Invalid generators length, must be equal to n.")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,9 @@ pub enum ProofError {
     /// proof with non-power-of-two aggregation size.
     #[fail(display = "Invalid aggregation size, m must be a power of 2")]
     InvalidAggregation,
+    /// This error occurs when the generators are of the wrong length.
+    #[fail(display = "Invalid generators length, must be equal to n.")]
+    InvalidGeneratorsLength,
     /// This error results from an internal error during proving.
     ///
     /// The single-party prover is implemented by performing

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -78,6 +78,12 @@ impl RangeProof {
         if values.len() != blindings.len() {
             return Err(ProofError::WrongNumBlindingFactors);
         }
+        if generators.n != n {
+            return Err(ProofError::InvalidGeneratorsLength);
+        }
+        if !(n == 8 || n == 16 || n == 32 || n == 64) {
+            return Err(ProofError::InvalidBitsize);
+        }
 
         let dealer = Dealer::new(generators, n, values.len(), transcript)?;
 
@@ -145,6 +151,12 @@ impl RangeProof {
     ) -> Result<(), ProofError> {
         // First, replay the "interactive" protocol using the proof
         // data to recompute all challenges.
+        if gens.n != n {
+            return Err(ProofError::InvalidGeneratorsLength);
+        }
+        if !(n == 8 || n == 16 || n == 32 || n == 64) {
+            return Err(ProofError::InvalidBitsize);
+        }
 
         let m = value_commitments.len();
 


### PR DESCRIPTION
Issue here: https://github.com/dalek-cryptography/bulletproofs/issues/108

Basically, when doing range proofs, check that `Generators` has `n` and `m` as powers of 2.