### PR TITLE
Update R1CS API

### DIFF
--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -96,7 +96,7 @@ impl<'a> ConstraintSystem<'a> {
             aL_assignments: vec![],
             aR_assignments: vec![],
             aO_assignments: vec![],
-            v_assignments: v_assignments,
+            v_assignments,
         };
 
         (cs, variables, commitments)
@@ -315,11 +315,8 @@ mod tests {
         );
 
         let (proof, verifier_input) = prover_cs.prove(&v_blinding, &gen, &mut rng)?;
-
         let actual_result = verifier_cs.verify(&proof, &verifier_input, &gen, &mut rng);
 
-        println!("expected result: {:?}", expected_result);
-        println!("actual result: {:?}", actual_result);
         match expected_result {
             Ok(_) => assert!(actual_result.is_ok()),
             Err(_) => assert!(actual_result.is_err()),

--- a/src/circuit_proof/r1cs.rs
+++ b/src/circuit_proof/r1cs.rs
@@ -151,7 +151,7 @@ impl ConstraintSystem {
 
     // Allocate a committed variable, and assign it the Assignment passed in.
     // Prover will pass in `Value(Scalar)`s, and Verifier will pass in `Missing`.
-    pub fn assign_committed(&mut self, value: Assignment) -> Variable {
+    fn assign_committed(&mut self, value: Assignment) -> Variable {
         self.v_assignments.push(value);
         Variable::Committed(self.v_assignments.len() - 1)
     }
@@ -349,12 +349,13 @@ mod tests {
         // empty commitments vec because there are no commitments in this test
         let v = vec![];
         let v_blinding = vec![];
-        let (mut prover_cs, _prover_committed_variables, commitments) = ConstraintSystem::prover_new(
-            prover_transcript,
-            v,
-            v_blinding.clone(),
-            PedersenGenerators::default(),
-        );
+        let (mut prover_cs, _prover_committed_variables, commitments) =
+            ConstraintSystem::prover_new(
+                prover_transcript,
+                v,
+                v_blinding.clone(),
+                PedersenGenerators::default(),
+            );
         prover_cs.assign_multiplier(
             Assignment::from(a),
             Assignment::from(b),


### PR DESCRIPTION
- require user to pass in a `Transcript` and `Commitments` to `ConstraintSystem::new()`, such that:
   - `ConstraintSystem` holds onto its own `Transcript`,
   - `ConstraintSystem` takes the `Commitments` and inputs them into the `Transcript`, which should be the only time that the `Transcript` takes inputs from that `ConstraintSystem` instance
- add a `get_challenge` function to `ConstraintSystem` so that gadgets can get challenge variables from the `Transcript`
- make `Variable` `Copy`-able