### PR TITLE
 Replace constant terms in LC by constant Variables 

### DIFF
--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -55,7 +55,7 @@ pub enum Variable {
     /// Represents the output of a multiplication gate.
     MultiplierOutput(usize),
     /// Represents the constant 1.
-    Constant(),
+    One(),
 }
 
 /// Represents a linear combination of `Variables`.  Each term is
@@ -168,7 +168,7 @@ mod tests {
         cs.add_constraint([(aL, -one), (a1.0, one), (a2.0, one)].iter().collect());
         cs.add_constraint([(aR, -one), (b1.0, one), (b2.0, one)].iter().collect());
         cs.add_constraint(
-            [(aO, -one), (c1.0, one), (Variable::Constant(), c2)]
+            [(aO, -one), (c1.0, one), (Variable::One(), c2)]
                 .iter()
                 .collect(),
         );

--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -4,6 +4,8 @@ pub mod assignment;
 pub mod prover;
 pub mod verifier;
 
+use std::iter::FromIterator;
+
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 
@@ -41,39 +43,52 @@ pub struct R1CSProof {
     ipp_proof: InnerProductProof,
 }
 
-/// The variables used in the `LinearCombination` and `ConstraintSystem` structs.
+/// Represents a variable in a constraint system.
 #[derive(Copy, Clone, Debug)]
 pub enum Variable {
-    Committed(usize),        // high-level variable
-    MultiplierLeft(usize),   // low-level variable, left input of multiplication gate
-    MultiplierRight(usize),  // low-level variable, right input of multiplication gate
-    MultiplierOutput(usize), // low-level variable, output multiplication gate
+    /// Represents an external input specified by a commitment.
+    Committed(usize),
+    /// Represents the left input of a multiplication gate.
+    MultiplierLeft(usize),
+    /// Represents the right input of a multiplication gate.
+    MultiplierRight(usize),
+    /// Represents the output of a multiplication gate.
+    MultiplierOutput(usize),
+    /// Represents the constant 1.
+    Constant(),
 }
 
-/// Represents a linear combination of some variables multiplied with their scalar coefficients,
-/// plus a scalar. `ConstraintSystem` expects all linear combinations to evaluate to zero.
-/// E.g. LC = variable[0]*scalar[0] + variable[1]*scalar[1] + scalar
+/// Represents a linear combination of `Variables`.  Each term is
+/// represented by a `(Variable, Scalar)` pair.
 #[derive(Clone, Debug)]
 pub struct LinearCombination {
-    variables: Vec<(Variable, Scalar)>,
-    constant: Scalar,
+    terms: Vec<(Variable, Scalar)>,
 }
 
-impl LinearCombination {
-    // TODO: make constructor with iterators
-    // see FromIterator trait - [(a1, v1), (a2, v2)].iter().collect() (pass in the iterator, collect to get LC)
-    pub fn new(variables: Vec<(Variable, Scalar)>, constant: Scalar) -> Self {
+impl Default for LinearCombination {
+    fn default() -> Self {
+        LinearCombination { terms: Vec::new() }
+    }
+}
+
+impl FromIterator<(Variable, Scalar)> for LinearCombination {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (Variable, Scalar)>,
+    {
         LinearCombination {
-            variables,
-            constant,
+            terms: iter.into_iter().collect(),
         }
     }
+}
 
-    // XXX this could be Default?
-    pub fn zero() -> Self {
+impl<'a> FromIterator<&'a (Variable, Scalar)> for LinearCombination {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = &'a (Variable, Scalar)>,
+    {
         LinearCombination {
-            variables: vec![],
-            constant: Scalar::zero(),
+            terms: iter.into_iter().cloned().collect(),
         }
     }
 }
@@ -127,25 +142,14 @@ mod tests {
         c1: (Variable, Assignment),
         c2: (Variable, Assignment),
     ) -> Result<(), R1CSError> {
-        let one = Scalar::one();
-        let zer = Scalar::zero();
-
         // Make low-level variables (aL = v_a1 + v_a2, aR = v_b1 + v_b2, aO = v_c1 + v_c2)
         let (aL, aR, aO) = cs.assign_multiplier(a1.1 + a2.1, b1.1 + b2.1, c1.1 + c2.1)?;
 
         // Tie high-level and low-level variables together
-        cs.add_constraint(LinearCombination::new(
-            vec![(aL, -one), (a1.0, one), (a2.0, one)],
-            zer,
-        ));
-        cs.add_constraint(LinearCombination::new(
-            vec![(aR, -one), (b1.0, one), (b2.0, one)],
-            zer,
-        ));
-        cs.add_constraint(LinearCombination::new(
-            vec![(aO, -one), (c1.0, one), (c2.0, one)],
-            zer,
-        ));
+        let one = Scalar::one();
+        cs.add_constraint([(aL, -one), (a1.0, one), (a2.0, one)].iter().collect());
+        cs.add_constraint([(aR, -one), (b1.0, one), (b2.0, one)].iter().collect());
+        cs.add_constraint([(aO, -one), (c1.0, one), (c2.0, one)].iter().collect());
 
         Ok(())
     }

--- a/src/circuit_proof/mod.rs
+++ b/src/circuit_proof/mod.rs
@@ -94,9 +94,9 @@ impl<'a> FromIterator<&'a (Variable, Scalar)> for LinearCombination {
 }
 
 pub trait ConstraintSystem {
-    // Allocate variables for left, right, and output wires of multiplication,
-    // and assign them the Assignments that are passed in.
-    // Prover will pass in `Value(Scalar)`s, and Verifier will pass in `Missing`s.
+    /// Allocate variables for left, right, and output wires of multiplication,
+    /// and assign them the Assignments that are passed in.
+    /// Prover will pass in `Value(Scalar)`s, and Verifier will pass in `Missing`s.
     fn assign_multiplier(
         &mut self,
         left: Assignment,
@@ -104,16 +104,31 @@ pub trait ConstraintSystem {
         out: Assignment,
     ) -> Result<(Variable, Variable, Variable), R1CSError>;
 
-    // Allocate two uncommitted variables, and assign them the Assignments passed in.
-    // Prover will pass in `Value(Scalar)`s, and Verifier will pass in `Missing`s.
+    /// Allocate two uncommitted variables, and assign them the Assignments passed in.
+    /// Prover will pass in `Value(Scalar)`s, and Verifier will pass in `Missing`s.
     fn assign_uncommitted(
         &mut self,
         val_1: Assignment,
         val_2: Assignment,
     ) -> Result<(Variable, Variable), R1CSError>;
 
+    /// Enforce that the given `LinearCombination` is zero.
     fn add_constraint(&mut self, lc: LinearCombination);
 
+    /// Obtain a challenge scalar bound to the assignments of all of
+    /// the externally committed wires.
+    ///
+    /// This allows the prover to select a challenge circuit from a
+    /// family of circuits parameterized by challenge scalars.
+    ///
+    /// # Warning
+    ///
+    /// The challenge scalars are bound only to the externally
+    /// committed wires (high-level witness variables), and not to the
+    /// assignments to all wires (low-level witness variables).  In
+    /// the same way that it is the user's responsibility to ensure
+    /// that the constraints are sound, it is **also** the user's
+    /// responsibility to ensure that each challenge circuit is sound.
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar;
 }
 

--- a/src/circuit_proof/prover.rs
+++ b/src/circuit_proof/prover.rs
@@ -146,7 +146,7 @@ impl<'a> ProverCS<'a> {
                     Variable::Committed(i) => {
                         z_zQ_WV[*i] -= exp_z * coeff;
                     }
-                    Variable::Constant() => {
+                    Variable::One() => {
                         // The prover doesn't need to handle constant terms
                     }
                 }

--- a/src/circuit_proof/prover.rs
+++ b/src/circuit_proof/prover.rs
@@ -132,7 +132,7 @@ impl<'a> ProverCS<'a> {
 
         let mut exp_z = *z;
         for lc in self.constraints.iter() {
-            for (var, coeff) in &lc.variables {
+            for (var, coeff) in &lc.terms {
                 match var {
                     Variable::MultiplierLeft(i) => {
                         z_zQ_WL[*i] += exp_z * coeff;
@@ -146,9 +146,11 @@ impl<'a> ProverCS<'a> {
                     Variable::Committed(i) => {
                         z_zQ_WV[*i] -= exp_z * coeff;
                     }
+                    Variable::Constant() => {
+                        // The prover doesn't need to handle constant terms
+                    }
                 }
             }
-
             exp_z *= z;
         }
 

--- a/src/circuit_proof/verifier.rs
+++ b/src/circuit_proof/verifier.rs
@@ -112,7 +112,7 @@ impl<'a> VerifierCS<'a> {
 
         let mut exp_z = *z;
         for lc in self.constraints.iter() {
-            for (var, coeff) in &lc.variables {
+            for (var, coeff) in &lc.terms {
                 match var {
                     Variable::MultiplierLeft(i) => {
                         z_zQ_WL[*i] += exp_z * coeff;
@@ -126,10 +126,11 @@ impl<'a> VerifierCS<'a> {
                     Variable::Committed(i) => {
                         z_zQ_WV[*i] -= exp_z * coeff;
                     }
+                    Variable::Constant() => {
+                        z_zQ_c -= exp_z * coeff;
+                    }
                 }
             }
-            z_zQ_c -= exp_z * lc.constant;
-
             exp_z *= z;
         }
 

--- a/src/circuit_proof/verifier.rs
+++ b/src/circuit_proof/verifier.rs
@@ -126,7 +126,7 @@ impl<'a> VerifierCS<'a> {
                     Variable::Committed(i) => {
                         z_zQ_WV[*i] -= exp_z * coeff;
                     }
-                    Variable::Constant() => {
+                    Variable::One() => {
                         z_zQ_c -= exp_z * coeff;
                     }
                 }


### PR DESCRIPTION
This replaces the constant term in the `LinearCombination` struct by adding a new `Constant` variant to the `Variable` enum which represents 1.

I changed the example gadget to use it by changing `c2` to be a constant.  I'm not sure whether this is the best possible API yet. WDYT?