### PR TITLE
Combine multiscalar mults in circuit verifier

### DIFF
--- a/src/circuit_proof/prover.rs
+++ b/src/circuit_proof/prover.rs
@@ -169,9 +169,9 @@ impl<'a, 'b> ProverCS<'a, 'b> {
     ///
     /// Returns a tuple of
     /// ```text
-    /// (z_zQ_WL, z_zQ_WR, z_zQ_WO, z_zQ_WV)
+    /// (wL, wR, wO, wV)
     /// ```
-    /// where `z_zQ_WL` is \\( z \cdot z^Q \cdot W_L \\), etc.
+    /// where `w{L,R,O}` is \\( z \cdot z^Q \cdot W_{L,R,O} \\).
     fn flattened_constraints(
         &mut self,
         z: &Scalar,
@@ -179,26 +179,26 @@ impl<'a, 'b> ProverCS<'a, 'b> {
         let n = self.a_L.len();
         let m = self.v.len();
 
-        let mut z_zQ_WL = vec![Scalar::zero(); n];
-        let mut z_zQ_WR = vec![Scalar::zero(); n];
-        let mut z_zQ_WO = vec![Scalar::zero(); n];
-        let mut z_zQ_WV = vec![Scalar::zero(); m];
+        let mut wL = vec![Scalar::zero(); n];
+        let mut wR = vec![Scalar::zero(); n];
+        let mut wO = vec![Scalar::zero(); n];
+        let mut wV = vec![Scalar::zero(); m];
 
         let mut exp_z = *z;
         for lc in self.constraints.iter() {
             for (var, coeff) in &lc.terms {
                 match var {
                     Variable::MultiplierLeft(i) => {
-                        z_zQ_WL[*i] += exp_z * coeff;
+                        wL[*i] += exp_z * coeff;
                     }
                     Variable::MultiplierRight(i) => {
-                        z_zQ_WR[*i] += exp_z * coeff;
+                        wR[*i] += exp_z * coeff;
                     }
                     Variable::MultiplierOutput(i) => {
-                        z_zQ_WO[*i] += exp_z * coeff;
+                        wO[*i] += exp_z * coeff;
                     }
                     Variable::Committed(i) => {
-                        z_zQ_WV[*i] -= exp_z * coeff;
+                        wV[*i] -= exp_z * coeff;
                     }
                     Variable::One() => {
                         // The prover doesn't need to handle constant terms
@@ -208,7 +208,7 @@ impl<'a, 'b> ProverCS<'a, 'b> {
             exp_z *= z;
         }
 
-        (z_zQ_WL, z_zQ_WR, z_zQ_WO, z_zQ_WV)
+        (wL, wR, wO, wV)
     }
 
     /// Consume this `ConstraintSystem` to produce a proof.

--- a/src/circuit_proof/prover.rs
+++ b/src/circuit_proof/prover.rs
@@ -297,7 +297,7 @@ impl<'a, 'b> ProverCS<'a, 'b> {
         let y = self.transcript.challenge_scalar(b"y");
         let z = self.transcript.challenge_scalar(b"z");
 
-        let (z_zQ_WL, z_zQ_WR, z_zQ_WO, z_zQ_WV) = self.flattened_constraints(&z);
+        let (wL, wR, wO, wV) = self.flattened_constraints(&z);
 
         let mut l_poly = util::VecPoly3::zero(n);
         let mut r_poly = util::VecPoly3::zero(n);
@@ -309,15 +309,15 @@ impl<'a, 'b> ProverCS<'a, 'b> {
         for i in 0..n {
             // l_poly.0 = 0
             // l_poly.1 = a_L + y^-n * (z * z^Q * W_R)
-            l_poly.1[i] = self.a_L[i] + exp_y_inv[i] * z_zQ_WR[i];
+            l_poly.1[i] = self.a_L[i] + exp_y_inv[i] * wR[i];
             // l_poly.2 = a_O
             l_poly.2[i] = self.a_O[i];
             // l_poly.3 = s_L
             l_poly.3[i] = s_L[i];
             // r_poly.0 = (z * z^Q * W_O) - y^n
-            r_poly.0[i] = z_zQ_WO[i] - exp_y;
+            r_poly.0[i] = wO[i] - exp_y;
             // r_poly.1 = y^n * a_R + (z * z^Q * W_L)
-            r_poly.1[i] = exp_y * self.a_R[i] + z_zQ_WL[i];
+            r_poly.1[i] = exp_y * self.a_R[i] + wL[i];
             // r_poly.2 = 0
             // r_poly.3 = y^n * s_R
             r_poly.3[i] = exp_y * s_R[i];
@@ -349,7 +349,7 @@ impl<'a, 'b> ProverCS<'a, 'b> {
 
         // t_2_blinding = <z*z^Q, W_V * v_blinding>
         // in the t_x_blinding calculations, line 76.
-        let t_2_blinding = z_zQ_WV
+        let t_2_blinding = wV
             .iter()
             .zip(self.v_blinding.iter())
             .map(|(c, v_blinding)| c * v_blinding)

--- a/src/circuit_proof/verifier.rs
+++ b/src/circuit_proof/verifier.rs
@@ -245,7 +245,8 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
         let xx = x * x;
         let y_inv = y.invert();
         let y_inv_vec = util::exp_iter(y_inv).take(n).collect::<Vec<Scalar>>();
-        let yneg_wR = wR.iter()
+        let yneg_wR = wR
+            .iter()
             .zip(y_inv_vec.iter())
             .map(|(wRi, exp_y_inv)| wRi * exp_y_inv)
             .collect::<Vec<Scalar>>();
@@ -253,15 +254,19 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
         let delta = inner_product(&yneg_wR, &wL);
 
         // define parameters for P check
-        let g = yneg_wR.iter()
+        let g = yneg_wR
+            .iter()
             .zip(s.iter().take(n))
-            .map(|(yneg_wRi, s_i)| x*yneg_wRi - a * s_i);
+            .map(|(yneg_wRi, s_i)| x * yneg_wRi - a * s_i);
 
-        let h = y_inv_vec.iter()
+        let h = y_inv_vec
+            .iter()
             .zip(s.iter().rev().take(n))
             .zip(wL.iter())
             .zip(wO.iter())
-            .map(|(((y_inv_i, s_i_inv), wLi), wOi)| y_inv_i * (x * wLi + wOi - b * s_i_inv) - Scalar::one());
+            .map(|(((y_inv_i, s_i_inv), wLi), wOi)| {
+                y_inv_i * (x * wLi + wOi - b * s_i_inv) - Scalar::one()
+            });
 
         // Create a `TranscriptRng` from the transcript
         use rand::thread_rng;
@@ -278,7 +283,7 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
             iter::once(x) // A_I
                 .chain(iter::once(xx)) // A_O
                 .chain(iter::once(x * xx)) // S
-                .chain(wV.iter().map(|wVi| wVi*rxx)) // V
+                .chain(wV.iter().map(|wVi| wVi * rxx)) // V
                 .chain(T_scalars.iter().cloned()) // T_points
                 .chain(iter::once(
                     w * (proof.t_x - a * b) + r * (xx * (wc + delta) - proof.t_x),
@@ -288,7 +293,6 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
                 .chain(h) // H
                 .chain(x_sq.iter().cloned()) // ipp_proof.L_vec
                 .chain(x_inv_sq.iter().cloned()), // ipp_proof.R_vec
-                
             iter::once(proof.A_I.decompress())
                 .chain(iter::once(proof.A_O.decompress()))
                 .chain(iter::once(proof.S.decompress()))
@@ -299,7 +303,7 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
                 .chain(gens.G(n).map(|&G_i| Some(G_i)))
                 .chain(gens.H(n).map(|&H_i| Some(H_i)))
                 .chain(proof.ipp_proof.L_vec.iter().map(|L_i| L_i.decompress()))
-                .chain(proof.ipp_proof.R_vec.iter().map(|R_i| R_i.decompress()))
+                .chain(proof.ipp_proof.R_vec.iter().map(|R_i| R_i.decompress())),
         )
         .ok_or_else(|| R1CSError::VerificationError)?;
 

--- a/src/circuit_proof/verifier.rs
+++ b/src/circuit_proof/verifier.rs
@@ -242,7 +242,7 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
 
         let a = proof.ipp_proof.a;
         let b = proof.ipp_proof.b;
-        let xx = x * x;
+
         let y_inv = y.invert();
         let y_inv_vec = util::exp_iter(y_inv).take(n).collect::<Vec<Scalar>>();
         let yneg_wR = wR
@@ -273,6 +273,7 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
         let mut rng = self.transcript.build_rng().finalize(&mut thread_rng());
         let r = Scalar::random(&mut rng);
 
+        let xx = x * x;
         let rxx = r * xx;
         let xxx = x * xx;
 

--- a/src/circuit_proof/verifier.rs
+++ b/src/circuit_proof/verifier.rs
@@ -274,15 +274,16 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
         let r = Scalar::random(&mut rng);
 
         let rxx = r * xx;
+        let xxx = x * xx;
 
         // group the T_scalars and T_points together
-        let T_scalars = [r * x, rxx * x, rxx * xx, rxx * xx * x, rxx * xx * xx];
+        let T_scalars = [r * x, rxx * x, rxx * xx, rxx * xxx, rxx * xx * xx];
         let T_points = [proof.T_1, proof.T_3, proof.T_4, proof.T_5, proof.T_6];
 
         let mega_check = RistrettoPoint::optional_multiscalar_mul(
             iter::once(x) // A_I
                 .chain(iter::once(xx)) // A_O
-                .chain(iter::once(x * xx)) // S
+                .chain(iter::once(xxx)) // S
                 .chain(wV.iter().map(|wVi| wVi * rxx)) // V
                 .chain(T_scalars.iter().cloned()) // T_points
                 .chain(iter::once(

--- a/src/circuit_proof/verifier.rs
+++ b/src/circuit_proof/verifier.rs
@@ -238,7 +238,7 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
         let (wL, wR, wO, wV, wc) = self.flattened_constraints(&z);
 
         // Get IPP variables
-        let (x_sq, x_inv_sq, s) = proof.ipp_proof.verification_scalars(self.transcript);
+        let (u_sq, u_inv_sq, s) = proof.ipp_proof.verification_scalars(self.transcript);
 
         let a = proof.ipp_proof.a;
         let b = proof.ipp_proof.b;
@@ -254,12 +254,12 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
         let delta = inner_product(&yneg_wR, &wL);
 
         // define parameters for P check
-        let g = yneg_wR
+        let g_scalars = yneg_wR
             .iter()
             .zip(s.iter().take(n))
             .map(|(yneg_wRi, s_i)| x * yneg_wRi - a * s_i);
 
-        let h = y_inv_vec
+        let h_scalars = y_inv_vec
             .iter()
             .zip(s.iter().rev().take(n))
             .zip(wL.iter())
@@ -291,10 +291,10 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
                     w * (proof.t_x - a * b) + r * (xx * (wc + delta) - proof.t_x),
                 )) // B
                 .chain(iter::once(-proof.e_blinding - r * proof.t_x_blinding)) // B_blinding
-                .chain(g) // G
-                .chain(h) // H
-                .chain(x_sq.iter().cloned()) // ipp_proof.L_vec
-                .chain(x_inv_sq.iter().cloned()), // ipp_proof.R_vec
+                .chain(g_scalars) // G
+                .chain(h_scalars) // H
+                .chain(u_sq.iter().cloned()) // ipp_proof.L_vec
+                .chain(u_inv_sq.iter().cloned()), // ipp_proof.R_vec
             iter::once(proof.A_I.decompress())
                 .chain(iter::once(proof.A_O.decompress()))
                 .chain(iter::once(proof.S.decompress()))


### PR DESCRIPTION
Addresses https://github.com/dalek-cryptography/bulletproofs/issues/148

All the checks are merged into one multi-scalar multiplication as described in the notes (#184):

<img width="926" alt="image" src="https://user-images.githubusercontent.com/698/46693549-005bac00-cbbf-11e8-8a61-ce9d4cb1491d.png">