### PR TITLE
Use Merlin v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = "1"
 serde_derive = "1"
 tiny-keccak = "1.4.1"
 failure = "0.1"
-merlin = "0.3"
+merlin = "0.4"
 
 [dev-dependencies]
 hex = "^0.3"

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -191,9 +191,7 @@ impl RangeProof {
 
         let w = transcript.challenge_scalar(b"w");
 
-        let mut rng = transcript
-            .fork_transcript()
-            .reseed_from_rng(&mut rand::thread_rng());
+        let mut rng = transcript.build_rng().finalize(&mut rand::thread_rng());
 
         // Challenge value for batching statements to be verified
         let c = Scalar::random(&mut rng);


### PR DESCRIPTION
Merlin 0.3->0.4 changes the `TranscriptRng` API.  In Bulletproofs, we only used that for the verifier's randomness, but that randomness can just use a `thread_rng` since there's no secrets to leak.