### PR TITLE
Implement PartialEq for Assignment

### DIFF
--- a/src/circuit_proof/assignment.rs
+++ b/src/circuit_proof/assignment.rs
@@ -148,6 +148,7 @@ impl ConditionallySelectable for Assignment {
             (Assignment::Value(a_val), Assignment::Value(b_val)) => {
                 // FIXME: use `Scalar::conditional_select(&a_val, &b_val, choice)` instead
                 // Currently that trait is not available because of a bug in `curve25519-dalek`.
+                // Filed issue: https://github.com/dalek-cryptography/curve25519-dalek/issues/200
                 let mut out_val = a_val.clone();
                 out_val.conditional_assign(&b_val, choice);
                 Assignment::from(out_val)

--- a/src/circuit_proof/assignment.rs
+++ b/src/circuit_proof/assignment.rs
@@ -1,5 +1,6 @@
 use curve25519_dalek::scalar::Scalar;
 use errors::R1CSError;
+use std::cmp::PartialEq;
 use std::ops::{Add, Div, Mul, Sub, Try};
 
 // The assignment value to a variable, as stored in `ConstraintSystem`.
@@ -135,5 +136,17 @@ impl Try for Assignment {
 
     fn from_ok(v: Self::Ok) -> Self {
         Assignment::Value(v)
+    }
+}
+
+impl PartialEq for Assignment {
+    fn eq(&self, other: &Assignment) -> bool {
+        match (self, other) {
+            (Assignment::Value(self_value), Assignment::Value(other_value)) => {
+                self_value == other_value
+            }
+            (Assignment::Missing(), Assignment::Missing()) => true,
+            _ => false,
+        }
     }
 }

--- a/src/circuit_proof/assignment.rs
+++ b/src/circuit_proof/assignment.rs
@@ -146,6 +146,8 @@ impl ConditionallySelectable for Assignment {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         match (a, b) {
             (Assignment::Value(a_val), Assignment::Value(b_val)) => {
+                // FIXME: use `Scalar::conditional_select(&a_val, &b_val, choice)` instead
+                // Currently that trait is not available because of a bug in `curve25519-dalek`.
                 let mut out_val = a_val.clone();
                 out_val.conditional_assign(&b_val, choice);
                 Assignment::from(out_val)

--- a/src/circuit_proof/assignment.rs
+++ b/src/circuit_proof/assignment.rs
@@ -2,6 +2,7 @@ use curve25519_dalek::scalar::Scalar;
 use errors::R1CSError;
 use std::cmp::PartialEq;
 use std::ops::{Add, Div, Mul, Sub, Try};
+use subtle::ConstantTimeEq;
 
 // The assignment value to a variable, as stored in `ConstraintSystem`.
 // Provers create a `Value` assignment, while verifiers create an `Missing` assignment.
@@ -143,7 +144,7 @@ impl PartialEq for Assignment {
     fn eq(&self, other: &Assignment) -> bool {
         match (self, other) {
             (Assignment::Value(self_value), Assignment::Value(other_value)) => {
-                self_value == other_value
+                bool::from(self_value.ct_eq(other_value))
             }
             (Assignment::Missing(), Assignment::Missing()) => true,
             _ => false,


### PR DESCRIPTION
This is extremely useful in the `cloak` gadgets, where the prover is comparing assignment values to determine the values of intermediate variables.