### PR TITLE
Add documentation and doctests to rangeproof code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ curve25519-dalek = { version = "0.19", features = ["serde"] }
 subtle = "0.7"
 sha3 = "0.7"
 digest = "0.7"
-rand = "0.5.0-pre.2"
-byteorder = "1.2.1"
+rand = "0.5"
+byteorder = "1"
 serde = "1"
 serde_derive = "1"
-tiny-keccak = "1.4.1"
 failure = "0.1"
 merlin = "0.4"
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,55 @@
-# Ristretto Bulletproofs
+# Bulletproofs
 
-A pure-Rust implementation of [Bulletproofs][bp_website] using [Ristretto][ristretto].
+The fastest [Bulletproofs][bp_website] implementation ever, featuring
+single and aggregated range proofs, strongly-typed multiparty
+computation, and a programmable constraint system API for proving
+arbitrary statements (under development).
 
-This crate contains both an implementation and a set of notes on how and why
-Bulletproofs work.  The [external documentation][doc_external] describes how to use this
-crate’s API, while the [internal documentation][doc_internal] contains the notes.
+This library implements Bulletproofs using [Ristretto][ristretto],
+using the `ristretto255` implementation in
+[`curve25519-dalek`][curve25519_dalek].  When using the [parallel
+formulas][parallel_edwards] in the `curve25519-dalek` AVX2 backend, it
+can verify 64-bit rangeproofs **approximately twice as fast** as the
+original `libsecp256k1`-based Bulletproofs implementation.
+
+This library provides implementations of:
+
+* Single-party proofs of single or multiple ranges, using the
+  aggregated rangeproof construction;
+
+* Online multi-party computation for rangeproof aggregation between
+  multiple parties, using [session types][session_type_blog] to
+  statically enforce correct protocol flow;
+  
+* A programmable constraint system API for expressing rank-1
+  constraint systems, and proving and verifying proofs of arbitrary
+  statements (under development in the `circuit` branch);
+  
+* Online multi-party computation for aggregated circuit proofs
+  (planned future work).
+  
+These proofs are implemented using [Merlin transcripts][doc_merlin],
+allowing them to be arbitrarily composed with other proofs without
+implementation changes.
+  
+The user-facing documentation for this functionality can be [found
+here][doc_external].  In addition, the library *also* contains
+extensive notes on how Bulletproofs work.  These notes can be found in
+the library's [internal documentation][doc_internal]:
+
+* how [Bulletproofs work][bp_notes];
+* how [the range proof protocol works][rp_notes];
+* how [the inner product proof protocol works][ipp_notes];
+* how [the aggregation protocol works][agg_notes];
+* how the Bulletproof circuit proofs work (under development);
+* how the constraint system reduction works (under development);
+* how the aggregated circuit proofs work (future work).
 
 ## WARNING
 
-This code is still research-quality.  It is not (yet) suitable for deployment.
-
-## Documentation
-
-* [Public API documentation][doc_external]
-* [Internal documentation][doc_internal]
-  * [Notes on how Bulletproofs work][bp_notes] (located in the internal `notes` module)
-  * [Range proof protocol description][rp_notes]
-  * [Inner product protocol description][ipp_notes]
-
-
-Unfortunately, `cargo doc` does not yet have support for custom HTML injection
-and for documenting private members, so the documentation is built using:
-
-```text
-make doc           # Builds external documentation
-make doc-internal  # Builds internal documentation
-```
-
-Note: `cargo doc --open` rebuilds the docs without the custom
-invocation, so it may be necessary to rerun `make`.
+This code is still research-quality.  It is not (yet) suitable for
+deployment.  The development roadmap can be found in the Milestones
+section of the Github repo.
 
 ## Tests
 
@@ -36,23 +57,24 @@ Run tests with `cargo test`.
 
 ## Benchmarks
 
-This crate uses [criterion.rs][criterion] for benchmarks.  Run benchmarks with
-`cargo bench`.
+This crate uses [criterion.rs][criterion] for benchmarks.  Run
+benchmarks with `cargo bench`.
 
 ## Features
 
-The `yolocrypto` feature enables the `yolocrypto` feature in
-`curve25519-dalek`, which enables the experimental AVX2 backend.  To use it for
-Bulletproofs, the `target_cpu` must support AVX2:
+The `avx2_backend` feature enables `curve25519-dalek`'s AVX2 backend,
+which implements curve arithmetic using [parallel
+formulas][parallel_edwards].  To use it for Bulletproofs, the
+`target_cpu` must support AVX2:
 
 ```text
-RUSTFLAGS="-C target_cpu=skylake" cargo bench --features "yolocrypto"
+RUSTFLAGS="-C target_cpu=skylake" cargo bench --features "avx2_backend"
 ```
 
 Skylake-X CPUs have double the AVX2 registers. To use them, try
 
 ```text
-RUSTFLAGS="-C target_cpu=skylake-avx512" cargo bench --features "yolocrypto"
+RUSTFLAGS="-C target_cpu=skylake-avx512" cargo bench --features "avx2_backend"
 ```
 
 This prevents spills in the AVX2 parallel field multiplication code, but causes
@@ -64,10 +86,15 @@ This is a research project being built for Chain, Inc, by Henry de Valence,
 Cathie Yun, and Oleg Andreev.
 
 [bp_website]: https://crypto.stanford.edu/bulletproofs/
-[ristretto]: https://doc.dalek.rs/curve25519_dalek/ristretto/index.html
-[doc_external]: https://doc.dalek.rs/ristretto_bulletproofs/index.html
-[doc_internal]: https://doc-internal.dalek.rs/ristretto_bulletproofs/index.html
-[bp_notes]: https://doc-internal.dalek.rs/ristretto_bulletproofs/notes/index.html
-[rp_notes]: https://doc-internal.dalek.rs/ristretto_bulletproofs/range_proof/index.html
-[ipp_notes]: https://doc-internal.dalek.rs/ristretto_bulletproofs/inner_product_proof/index.html
+[ristretto]: https://ristretto.group
+[doc_merlin]: https://doc.dalek.rs/merlin/index.html
+[doc_external]: https://doc.dalek.rs/bulletproofs/index.html
+[doc_internal]: https://doc-internal.dalek.rs/bulletproofs/index.html
+[bp_notes]: https://doc-internal.dalek.rs/bulletproofs/notes/index.html
+[rp_notes]: https://doc-internal.dalek.rs/bulletproofs/range_proof/index.html
+[ipp_notes]: https://doc-internal.dalek.rs/bulletproofs/inner_product_proof/index.html
+[agg_notes]: https://doc-internal.dalek.rs/bulletproofs/notes/index.html#aggregated-range-proof
 [criterion]: https://github.com/japaric/criterion.rs
+[session_type_blog]: https://blog.chain.com/bulletproof-multi-party-computation-in-rust-with-session-types-b3da6e928d5d
+[curve25519_dalek]: https://doc.dalek.rs/curve25519_dalek/index.html
+[parallel_edwards]: https://medium.com/@hdevalence/accelerating-edwards-curve-arithmetic-with-parallel-formulas-ac12cf5015be

--- a/benches/bulletproofs.rs
+++ b/benches/bulletproofs.rs
@@ -9,9 +9,11 @@ use rand::Rng;
 extern crate curve25519_dalek;
 use curve25519_dalek::scalar::Scalar;
 
+extern crate merlin;
+use merlin::Transcript;
+
 extern crate bulletproofs;
 use bulletproofs::RangeProof;
-use bulletproofs::Transcript;
 use bulletproofs::{BulletproofGens, PedersenGens};
 
 static AGGREGATION_SIZES: [usize; 6] = [1, 2, 4, 8, 16, 32];

--- a/benches/bulletproofs.rs
+++ b/benches/bulletproofs.rs
@@ -91,14 +91,14 @@ fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
             let value_commitments: Vec<_> = values
                 .iter()
                 .zip(blindings.iter())
-                .map(|(&v, &v_blinding)| pc_gens.commit(v.into(), v_blinding))
+                .map(|(&v, &v_blinding)| pc_gens.commit(v.into(), v_blinding).compress())
                 .collect();
 
             b.iter(|| {
                 // Each proof creation requires a clean transcript.
                 let mut transcript = Transcript::new(b"AggregateRangeProofBenchmark");
 
-                proof.verify(&bp_gens, &pc_gens, &mut transcript, &value_commitments, n)
+                proof.verify_multiple(&bp_gens, &pc_gens, &mut transcript, &value_commitments, n)
             });
         },
         &AGGREGATION_SIZES,

--- a/docs/aggregation-api.md
+++ b/docs/aggregation-api.md
@@ -9,7 +9,7 @@ To create the aggregated range proof, \\(m\\) individual parties which each have
 
 First, \\(m\\) [`Party`](../range_proof/party/struct.Party.html) objects are instantiated with their secret values and the range for the range proof. A [`Dealer`](../range_proof/dealer/struct.Dealer.html) object is instantiated with \\(n\\) and \\(m\\). The dealer assigns a unique index \\(j\\) to each party.
 
-Next, each `Party` commits to their secret value, bits, and blinding factors via \\(V_{(j)}, A_{(j)}, S_{(j)}\\) and sends this data in a [`ValueCommitment`](../range_proof/messages/struct.ValueCommitment.html) to the dealer. The dealer receives and combines all of the `ValueCommitment` messages from all of the parties, generates challenges \\(y, z\\), and sends \\(y, z\\) as [`ValueChallenge`](../range_proof/messages/struct.ValueChallenge.html) to all of the parties.
+Next, each `Party` commits to their secret value, bits, and blinding factors via \\(V_{(j)}, A_{(j)}, S_{(j)}\\) and sends this data in a [`BitCommitment`](../range_proof/messages/struct.BitCommitment.html) to the dealer. The dealer receives and combines all of the `BitCommitment` messages from all of the parties, generates challenges \\(y, z\\), and sends \\(y, z\\) as [`BitChallenge`](../range_proof/messages/struct.BitChallenge.html) to all of the parties.
 
 Then, each party commits to the resulting polynomials via \\(T_{1, (j)}, T_{2, (j)}\\) and sends this data in a `PolyCommitment` to the dealer. The dealer receives and combines all of the [`PolyCommitment`](../range_proof/messages/struct.PolyCommitment.html) messages from all of the parties, generates challenge \\(x\\), and sends \\(x\\) as [`PolyChallenge`](../range_proof/messages/struct.PolyChallenge.html) to all of the parties.
 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -623,7 +623,7 @@ New notation for aggregated proofs
 
 The subscript \\({(j)}\\) denotes the \\(j\\)th party's share. For instance, \\(v_{(j)}\\) is the \\(v\\) value of the \\(j\\)th party; \\( \mathbf{a}\_{L, (j)}\\) is the \\( \mathbf{a}\_L \\) vector of the \\(j\\)th party; \\(\mathbf{l}\_{(0)}(x)\\) is the \\(\mathbf{l}(x)\\) polynomial of party \\(0\\). 
 
-We use pythonic notation to denote slices of vectors, such that \\(\mathbf{G}\_{[a:b]} = [\mathbf{G}\_{a}, \mathbf{G}\_{a+1}, \dots, \mathbf{G}\_{b-1} ]\\).
+We use pythonic notation to denote slices of vectors, such that \\(\mathbf{G}\_{\[a:b\]} = [\mathbf{G}\_{a}, \mathbf{G}\_{a+1}, \dots, \mathbf{G}\_{b-1} ]\\).
 
 \\({\mathbf{G}\_{(j)}}\\) is party \\(j\\)'s share of the generators \\({\mathbf{G}}\\), or \\({\mathbf{G}\_{[j\cdot n : (j+1)n]}}\\), and \\({\mathbf{H}'\_{(j)}}\\) is party \\(j\\)'s share of the generators \\({\mathbf{H}'}\\), or \\({\mathbf{H}'\_{[j\cdot n : (j+1)n]}}\\).
 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -287,8 +287,8 @@ Instead, the prover chooses vectors of blinding factors
 and uses them to construct vector polynomials
 \\[
 \begin{aligned}
-  {\mathbf{l}}(x) &= {\mathbf{l}}\_{0} + {\mathbf{l}}\_{1} x = ({\mathbf{a}}\_{L} + {\mathbf{s}}\_{L} x) - z {\mathbf{1}} & \in {\mathbb Z\_p}[x]^{n}  \\\\
-  {\mathbf{r}}(x) &= {\mathbf{r}}\_{0} + {\mathbf{r}}\_{1} x = {\mathbf{y}}^{n} \circ \left( ({\mathbf{a}}\_{R} + {\mathbf{s}}\_{R} x\right)  + z {\mathbf{1}}) + z^{2} {\mathbf{2}}^{n} &\in {\mathbb Z\_p}[x]^{n} 
+  {\mathbf{l}}(x) &= {\mathbf{l}}\_{0} + {\mathbf{l}}\_{1} x = ({\mathbf{a}}\_{L} + {\mathbf{s}}\_{L} x) - z {\mathbf{1}} & \in {\mathbb Z\_p}\[x\]^{n}  \\\\
+  {\mathbf{r}}(x) &= {\mathbf{r}}\_{0} + {\mathbf{r}}\_{1} x = {\mathbf{y}}^{n} \circ \left( ({\mathbf{a}}\_{R} + {\mathbf{s}}\_{R} x\right)  + z {\mathbf{1}}) + z^{2} {\mathbf{2}}^{n} &\in {\mathbb Z\_p}\[x\]^{n} 
 \end{aligned}
 \\]
 These are the left and right sides of the combined inner product with \\({\mathbf{a}}\_{L}\\), \\({\mathbf{a}}\_{R}\\)
@@ -692,8 +692,8 @@ The prover chooses vectors of blinding factors \\( \mathbf{s}\_{L, (j)}, {\mathb
 
 \\[
 \begin{aligned}
-  {\mathbf{l}}\_{(j)}(x) &= ({\mathbf{a}}\_{L, (j)} + {\mathbf{s}}\_{L, (j)} x) - z {\mathbf{1}} & \in {\mathbb Z\_p}[x]^{n}  \\\\
-  {\mathbf{r}}\_{(j)}(x) &= {\mathbf{y}}^{n}\_{(j)} \circ \left( ({\mathbf{a}}\_{R, (j)} + {\mathbf{s}}\_{R, (j)} x\right)  + z {\mathbf{1}}) + z^{2} z_{(j)} {\mathbf{2}}^{n} &\in {\mathbb Z\_p}[x]^{n} 
+  {\mathbf{l}}\_{(j)}(x) &= ({\mathbf{a}}\_{L, (j)} + {\mathbf{s}}\_{L, (j)} x) - z {\mathbf{1}} & \in {\mathbb Z\_p}\[x\]^{n}  \\\\
+  {\mathbf{r}}\_{(j)}(x) &= {\mathbf{y}}^{n}\_{(j)} \circ \left( ({\mathbf{a}}\_{R, (j)} + {\mathbf{s}}\_{R, (j)} x\right)  + z {\mathbf{1}}) + z^{2} z_{(j)} {\mathbf{2}}^{n} &\in {\mathbb Z\_p}\[x\]^{n} 
 \end{aligned}
 \\]
 

--- a/docs/range-proof-protocol.md
+++ b/docs/range-proof-protocol.md
@@ -31,7 +31,7 @@ S_{(j)} &\gets \operatorname{Com}({\mathbf{s}}\_{L, (j)}, {\mathbf{s}}\_{R, (j)}
 \\] where \\(\widetilde{v}\_{(j)}, \widetilde{a}\_{(j)}, \widetilde{s}\_{(j)}\\) are sampled randomly
 from \\({\mathbb Z\_p}\\) and \\(\mathbf{s}\_{L, (j)}, \mathbf{s}\_{R, (j)}\\) are sampled randomly from \\({\mathbb Z\_p}^{n}\\).
 
-The parties all send their \\(V_{(j)}\\), \\(A_{(j)}\\), and \\(S_{(j)}\\) values to the dealer as `ValueCommitment`. The dealer adds each \\(V_{(j)}\\) value to the protocol transcript, in order. The dealer then computes \\(A\\) and \\(S\\) as follows:
+The parties all send their \\(V_{(j)}\\), \\(A_{(j)}\\), and \\(S_{(j)}\\) values to the dealer as `BitCommitment`. The dealer adds each \\(V_{(j)}\\) value to the protocol transcript, in order. The dealer then computes \\(A\\) and \\(S\\) as follows:
 
 \\[
 \begin{aligned}
@@ -40,9 +40,9 @@ The parties all send their \\(V_{(j)}\\), \\(A_{(j)}\\), and \\(S_{(j)}\\) value
 \end{aligned}
 \\]
 
-The dealer adds \\(A\\) and \\(S\\) to the protocol transcript and obtains challenge scalars \\(y,z \in {\mathbb Z\_p}\\) from the transcript. The dealer sends \\(y, z\\) as `ValueChallenge` to all of the parties.
+The dealer adds \\(A\\) and \\(S\\) to the protocol transcript and obtains challenge scalars \\(y,z \in {\mathbb Z\_p}\\) from the transcript. The dealer sends \\(y, z\\) as `BitChallenge` to all of the parties.
 
-Using their secret vectors and the challenges \\(y, z\\) from `ValueChallenge`, each party constructs vector polynomials:
+Using their secret vectors and the challenges \\(y, z\\) from `BitChallenge`, each party constructs vector polynomials:
 \\[
 \begin{aligned}
   {\mathbf{l}}\_{(j)}(x) &= {\mathbf{l}}\_{0, (j)} + {\mathbf{l}}\_{1, (j)} x \\\\

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -72,7 +72,7 @@ pub enum MPCError {
     /// This error occurs when the dealer is given the wrong number of
     /// value commitments.
     #[fail(display = "Wrong number of value commitments")]
-    WrongNumValueCommitments,
+    WrongNumBitCommitments,
     /// This error occurs when the dealer is given the wrong number of
     /// polynomial commitments.
     #[fail(display = "Wrong number of value commitments")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,13 @@
 #![feature(nll)]
 #![feature(external_doc)]
+#![deny(missing_docs)]
 #![doc(include = "../README.md")]
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
 
-//! Note that docs will only build on nightly Rust until
-//! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
-
 extern crate byteorder;
 extern crate core;
-extern crate rand;
 extern crate digest;
+extern crate rand;
 extern crate sha3;
 
 extern crate curve25519_dalek;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
-#![cfg_attr(feature = "bench", feature(test))]
 #![feature(nll)]
-#![feature(test)]
 #![feature(external_doc)]
 #![doc(include = "../README.md")]
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
@@ -25,8 +23,6 @@ extern crate serde;
 
 #[cfg(test)]
 extern crate bincode;
-#[cfg(test)]
-extern crate test;
 
 mod util;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,6 @@ mod inner_product_proof;
 mod range_proof;
 mod transcript;
 
-pub use merlin::Transcript;
-
 pub use errors::ProofError;
 pub use generators::{BulletproofGens, BulletproofGensShare, PedersenGens};
 pub use range_proof::RangeProof;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,18 +8,20 @@
 
 extern crate byteorder;
 extern crate core;
-extern crate curve25519_dalek;
-extern crate digest;
-#[macro_use]
-extern crate failure;
-extern crate merlin;
 extern crate rand;
+extern crate digest;
 extern crate sha3;
+
+extern crate curve25519_dalek;
+extern crate merlin;
 extern crate subtle;
-extern crate tiny_keccak;
+
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
+
+#[macro_use]
+extern crate failure;
 
 #[cfg(test)]
 extern crate bincode;

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -267,7 +267,12 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
     pub fn receive_shares(mut self, proof_shares: &[ProofShare]) -> Result<RangeProof, MPCError> {
         let proof = self.assemble_shares(proof_shares)?;
 
-        let V: Vec<_> = self.value_commitments.iter().map(|vc| vc.V_j).collect();
+        // XXX ValueCommitments should have compressed points
+        let V: Vec<_> = self
+            .value_commitments
+            .iter()
+            .map(|vc| vc.V_j.compress())
+            .collect();
 
         // See comment in `Dealer::new` for why we use `initial_transcript`
         let transcript = &mut self.initial_transcript;

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -272,7 +272,7 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
         // See comment in `Dealer::new` for why we use `initial_transcript`
         let transcript = &mut self.initial_transcript;
         if proof
-            .verify(self.bp_gens, self.pc_gens, transcript, &V, self.n)
+            .verify_multiple(self.bp_gens, self.pc_gens, transcript, &V, self.n)
             .is_ok()
         {
             Ok(proof)

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -10,17 +10,16 @@ use curve25519_dalek::scalar::Scalar;
 use generators::{BulletproofGens, PedersenGens};
 
 /// A commitment to the bits of a party's value.
-/// XXX rename this to `BitCommitment`
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
-pub struct ValueCommitment {
+pub struct BitCommitment {
     pub(super) V_j: RistrettoPoint,
     pub(super) A_j: RistrettoPoint,
     pub(super) S_j: RistrettoPoint,
 }
 
-/// Challenge values derived from all parties' [`ValueCommitment`]s.
+/// Challenge values derived from all parties' [`BitCommitment`]s.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
-pub struct ValueChallenge {
+pub struct BitChallenge {
     pub(super) y: Scalar,
     pub(super) z: Scalar,
 }
@@ -57,8 +56,8 @@ impl ProofShare {
         bp_gens: &BulletproofGens,
         pc_gens: &PedersenGens,
         j: usize,
-        value_commitment: &ValueCommitment,
-        value_challenge: &ValueChallenge,
+        value_commitment: &BitCommitment,
+        value_challenge: &BitChallenge,
         poly_commitment: &PolyCommitment,
         poly_challenge: &PolyChallenge,
     ) -> Result<(), ()> {

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -9,45 +9,50 @@ use curve25519_dalek::scalar::Scalar;
 
 use generators::{BulletproofGens, PedersenGens};
 
+/// A commitment to the bits of a party's value.
 /// XXX rename this to `BitCommitment`
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct ValueCommitment {
-    pub V_j: RistrettoPoint,
-    pub A_j: RistrettoPoint,
-    pub S_j: RistrettoPoint,
+    pub(super) V_j: RistrettoPoint,
+    pub(super) A_j: RistrettoPoint,
+    pub(super) S_j: RistrettoPoint,
 }
 
+/// Challenge values derived from all parties' [`ValueCommitment`]s.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct ValueChallenge {
-    pub y: Scalar,
-    pub z: Scalar,
+    pub(super) y: Scalar,
+    pub(super) z: Scalar,
 }
 
+/// A commitment to a party's polynomial coefficents.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct PolyCommitment {
-    pub T_1_j: RistrettoPoint,
-    pub T_2_j: RistrettoPoint,
+    pub(super) T_1_j: RistrettoPoint,
+    pub(super) T_2_j: RistrettoPoint,
 }
 
+/// Challenge values derived from all parties' [`PolyCommitment`]s.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct PolyChallenge {
-    pub x: Scalar,
+    pub(super) x: Scalar,
 }
 
+/// A party's proof share, ready for aggregation into the final
+/// [`RangeProof`](::RangeProof).
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ProofShare {
-    pub t_x: Scalar,
-    pub t_x_blinding: Scalar,
-    pub e_blinding: Scalar,
-
-    pub l_vec: Vec<Scalar>,
-    pub r_vec: Vec<Scalar>,
+    pub(super) t_x: Scalar,
+    pub(super) t_x_blinding: Scalar,
+    pub(super) e_blinding: Scalar,
+    pub(super) l_vec: Vec<Scalar>,
+    pub(super) r_vec: Vec<Scalar>,
 }
 
 impl ProofShare {
     /// Audit an individual proof share to determine whether it is
     /// malformed.
-    pub(crate) fn audit_share(
+    pub(super) fn audit_share(
         &self,
         bp_gens: &BulletproofGens,
         pc_gens: &PedersenGens,

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -191,7 +191,7 @@ impl RangeProof {
     /// let mut transcript = Transcript::new(b"doctest example");
     /// assert!(
     ///     proof
-    ///         .verify(&bp_gens, &pc_gens, &mut transcript, &commitments, 32)
+    ///         .verify_multiple(&bp_gens, &pc_gens, &mut transcript, &commitments, 32)
     ///         .is_ok()
     /// );
     /// # }
@@ -257,7 +257,7 @@ impl RangeProof {
 
     /// Verifies a rangeproof for a given value commitment \\(V\\).
     ///
-    /// This is a convenience wrapper around `verify` for the `m=1` case.
+    /// This is a convenience wrapper around `verify_multiple` for the `m=1` case.
     pub fn verify_single(
         &self,
         bp_gens: &BulletproofGens,
@@ -266,11 +266,11 @@ impl RangeProof {
         V: &RistrettoPoint,
         n: usize,
     ) -> Result<(), ProofError> {
-        self.verify(bp_gens, pc_gens, transcript, &[*V], n)
+        self.verify_multiple(bp_gens, pc_gens, transcript, &[*V], n)
     }
 
     /// Verifies an aggregated rangeproof for the given value commitments.
-    pub fn verify(
+    pub fn verify_multiple(
         &self,
         bp_gens: &BulletproofGens,
         pc_gens: &PedersenGens,
@@ -595,7 +595,7 @@ mod tests {
 
             assert!(
                 proof
-                    .verify(&bp_gens, &pc_gens, &mut transcript, &value_commitments, n)
+                    .verify_multiple(&bp_gens, &pc_gens, &mut transcript, &value_commitments, n)
                     .is_ok()
             );
         }

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -71,7 +71,7 @@ pub struct RangeProof {
 impl RangeProof {
     /// Create a rangeproof for a given pair of value `v` and
     /// blinding scalar `v_blinding`.
-    /// This is a convenience wrapper around [`prove_multiple`].
+    /// This is a convenience wrapper around [`RangeProof::prove_multiple`].
     ///
     /// # Example
     /// ```

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -45,7 +45,7 @@ pub mod party;
 /// # Note
 ///
 /// For proving, these functions run the multiparty aggregation
-/// protocol locally.  That API is exposed in the [`aggregation`]
+/// protocol locally.  That API is exposed in the [`aggregation`](::aggregation)
 /// module and can be used to perform online aggregation between
 /// parties without revealing secret values to each other.
 #[derive(Clone, Debug)]

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -25,7 +25,29 @@ pub mod dealer;
 pub mod messages;
 pub mod party;
 
-/// The `RangeProof` struct represents a single range proof.
+/// The `RangeProof` struct represents a proof that one or more values
+/// are in a range.
+///
+/// The `RangeProof` struct contains functions for creating and
+/// verifying aggregated range proofs.  The single-value case is
+/// implemented as a special case of aggregated range proofs.
+///
+/// The bitsize of the range, as well as the list of commitments to
+/// the values, are not included in the proof, and must be known to
+/// the verifier.
+///
+/// This implementation requires that both the bitsize `n` and the
+/// aggregation size `m` be powers of two, so that `n = 8, 16, 32, 64`
+/// and `m = 1, 2, 4, 8, 16, ...`.  Note that the aggregation size is
+/// not given as an explicit parameter, but is determined by the
+/// number of values or commitments passed to the prover or verifier.
+///
+/// # Note
+///
+/// For proving, these functions run the multiparty aggregation
+/// protocol locally.  That API is exposed in the [`aggregation`]
+/// module and can be used to perform online aggregation between
+/// parties without revealing secret values to each other.
 #[derive(Clone, Debug)]
 pub struct RangeProof {
     /// Commitment to the bits of the value
@@ -49,8 +71,61 @@ pub struct RangeProof {
 impl RangeProof {
     /// Create a rangeproof for a given pair of value `v` and
     /// blinding scalar `v_blinding`.
+    /// This is a convenience wrapper around [`prove_multiple`].
     ///
-    /// XXX add doctests
+    /// # Example
+    /// ```
+    /// extern crate rand;
+    /// use rand::thread_rng;
+    ///
+    /// extern crate curve25519_dalek;
+    /// use curve25519_dalek::scalar::Scalar;
+    ///
+    /// extern crate merlin;
+    /// use merlin::Transcript;
+    ///
+    /// extern crate bulletproofs;
+    /// use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};
+    ///
+    /// # fn main() {
+    /// // Generators for Pedersen commitments.  These can be selected
+    /// // independently of the Bulletproofs generators.
+    /// let pc_gens = PedersenGens::default();
+    ///
+    /// // Generators for Bulletproofs, valid for proofs up to bitsize 64
+    /// // and aggregation size up to 1.
+    /// let bp_gens = BulletproofGens::new(64, 1);
+    ///
+    /// // A secret value we want to prove lies in the range [0, 2^32)
+    /// let secret_value = 1037578891u64;
+    ///
+    /// // The API takes an opening to an existing commitment, so create one:
+    /// let blinding = Scalar::random(&mut thread_rng());
+    /// let committed_value = pc_gens.commit(secret_value.into(), blinding);
+    ///
+    /// // The proof can be chained to an existing transcript.
+    /// // Here we create a transcript with a doctest domain separator.
+    /// let mut transcript = Transcript::new(b"doctest example");
+    ///
+    /// // Create a 32-bit rangeproof.
+    /// let proof = RangeProof::prove_single(
+    ///     &bp_gens,
+    ///     &pc_gens,
+    ///     &mut transcript,
+    ///     secret_value,
+    ///     &blinding,
+    ///     32,
+    /// ).expect("A real program could handle errors");
+    ///
+    /// // Verification requires a transcript with identical initial state:
+    /// let mut transcript = Transcript::new(b"doctest example");
+    /// assert!(
+    ///     proof
+    ///         .verify_single(&bp_gens, &pc_gens, &mut transcript, &committed_value, 32)
+    ///         .is_ok()
+    /// );
+    /// # }
+    /// ```
     pub fn prove_single(
         bp_gens: &BulletproofGens,
         pc_gens: &PedersenGens,
@@ -64,7 +139,63 @@ impl RangeProof {
 
     /// Create a rangeproof for a set of values.
     ///
-    /// XXX add doctests
+    /// # Example
+    /// ```
+    /// extern crate rand;
+    /// use rand::thread_rng;
+    ///
+    /// extern crate curve25519_dalek;
+    /// use curve25519_dalek::scalar::Scalar;
+    ///
+    /// extern crate merlin;
+    /// use merlin::Transcript;
+    ///
+    /// extern crate bulletproofs;
+    /// use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};
+    ///
+    /// # fn main() {
+    /// // Generators for Pedersen commitments.  These can be selected
+    /// // independently of the Bulletproofs generators.
+    /// let pc_gens = PedersenGens::default();
+    ///
+    /// // Generators for Bulletproofs, valid for proofs up to bitsize 64
+    /// // and aggregation size up to 16.
+    /// let bp_gens = BulletproofGens::new(64, 16);
+    ///
+    /// // Four secret values we want to prove lie in the range [0, 2^32)
+    /// let secrets = [4242344947u64, 3718732727u64, 2255562556u64, 2526146994u64];
+    ///
+    /// // The API takes openings to existing commitments, so create them:
+    /// let blindings: Vec<_> = (0..4).map(|_| Scalar::random(&mut thread_rng())).collect();
+    /// let commitments: Vec<_> = secrets
+    ///     .iter()
+    ///     .zip(blindings.iter())
+    ///     .map(|(&v, &v_blinding)| pc_gens.commit(v.into(), v_blinding))
+    ///     .collect();
+    ///
+    /// // The proof can be chained to an existing transcript.
+    /// // Here we create a transcript with a doctest domain separator.
+    /// let mut transcript = Transcript::new(b"doctest example");
+    ///
+    /// // Create an aggregated 32-bit rangeproof.
+    /// let proof = RangeProof::prove_multiple(
+    ///     &bp_gens,
+    ///     &pc_gens,
+    ///     &mut transcript,
+    ///     &secrets,
+    ///     &blindings,
+    ///     32,
+    /// ).expect("A real program could handle errors");
+    ///
+    /// // Verification requires a transcript with identical initial state:
+    /// let mut transcript = Transcript::new(b"doctest example");
+    /// assert!(
+    ///     proof
+    ///         .verify(&bp_gens, &pc_gens, &mut transcript, &commitments, 32)
+    ///         .is_ok()
+    /// );
+    /// # }
+    /// ```
     pub fn prove_multiple(
         bp_gens: &BulletproofGens,
         pc_gens: &PedersenGens,
@@ -127,8 +258,6 @@ impl RangeProof {
     /// Verifies a rangeproof for a given value commitment \\(V\\).
     ///
     /// This is a convenience wrapper around `verify` for the `m=1` case.
-    ///
-    /// XXX add doctests
     pub fn verify_single(
         &self,
         bp_gens: &BulletproofGens,
@@ -141,8 +270,6 @@ impl RangeProof {
     }
 
     /// Verifies an aggregated rangeproof for the given value commitments.
-    ///
-    /// XXX add doctests
     pub fn verify(
         &self,
         bp_gens: &BulletproofGens,
@@ -167,7 +294,7 @@ impl RangeProof {
 
         transcript.rangeproof_domain_sep(n as u64, m as u64);
 
-        // TODO: allow user to supply compressed commitments
+        // XXX: allow user to supply compressed commitments
         // to avoid unnecessary compression
         for V in value_commitments.iter() {
             transcript.commit_point(b"V", &V.compress());

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -68,7 +68,7 @@ impl<'a> PartyAwaitingPosition<'a> {
         self,
         // XXX need to check that j is valid (in gens range)
         j: usize,
-    ) -> (PartyAwaitingValueChallenge<'a>, ValueCommitment) {
+    ) -> (PartyAwaitingBitChallenge<'a>, BitCommitment) {
         // XXX use transcript RNG
         let mut rng = rand::thread_rng();
 
@@ -103,12 +103,12 @@ impl<'a> PartyAwaitingPosition<'a> {
         );
 
         // Return next state and all commitments
-        let value_commitment = ValueCommitment {
+        let value_commitment = BitCommitment {
             V_j: self.V,
             A_j: A,
             S_j: S,
         };
-        let next_state = PartyAwaitingValueChallenge {
+        let next_state = PartyAwaitingBitChallenge {
             n: self.n,
             v: self.v,
             v_blinding: self.v_blinding,
@@ -125,7 +125,7 @@ impl<'a> PartyAwaitingPosition<'a> {
 
 /// A party which has committed to the bits of its value
 /// and is waiting for the aggregated value challenge from the dealer.
-pub struct PartyAwaitingValueChallenge<'a> {
+pub struct PartyAwaitingBitChallenge<'a> {
     n: usize, // bitsize of the range
     v: u64,
     v_blinding: Scalar,
@@ -137,12 +137,12 @@ pub struct PartyAwaitingValueChallenge<'a> {
     s_R: Vec<Scalar>,
 }
 
-impl<'a> PartyAwaitingValueChallenge<'a> {
-    /// Receive a [`ValueChallenge`] from the dealer and use it to
+impl<'a> PartyAwaitingBitChallenge<'a> {
+    /// Receive a [`BitChallenge`] from the dealer and use it to
     /// compute commitments to the party's polynomial coefficients.
     pub fn apply_challenge(
         self,
-        vc: &ValueChallenge,
+        vc: &BitChallenge,
     ) -> (PartyAwaitingPolyChallenge, PolyCommitment) {
         let mut rng = rand::thread_rng();
 


### PR DESCRIPTION
This adds `#![deny(missing_docs)]`, so it will probably require changes to the `circuit` branch the next time we sync the two branches (since it will force documenting all of the circuit API).

Closes #162 