### PR TITLE
Update to stable subtle 1.0, curve25519-dalek 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["cryptography", "ristretto", "zero-knowledge", "bulletproofs"]
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
-curve25519-dalek = { version = "0.19", features = ["serde"] }
-subtle = "0.7"
+curve25519-dalek = { version = "0.20", features = ["serde"] }
+subtle = "1"
 sha3 = "0.7"
 digest = "0.7"
 rand = "0.5.0-pre.2"
@@ -25,7 +25,7 @@ failure = "0.1"
 merlin = "0.4"
 
 [dev-dependencies]
-hex = "^0.3"
+hex = "0.3"
 criterion = "0.2"
 bincode = "1"
 


### PR DESCRIPTION
After this is merged into `main`, it can be cherry-picked into `circuit` for use in #166, #168.