### PR TITLE
Streamline range proof Party/Dealer APIs

### DIFF
--- a/benches/bulletproofs.rs
+++ b/benches/bulletproofs.rs
@@ -81,7 +81,7 @@ fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
             let blindings: Vec<Scalar> = (0..m).map(|_| Scalar::random(&mut rng)).collect();
 
             let mut transcript = Transcript::new(b"AggregateRangeProofBenchmark");
-            let proof = RangeProof::prove_multiple(
+            let (proof, value_commitments) = RangeProof::prove_multiple(
                 &bp_gens,
                 &pc_gens,
                 &mut transcript,
@@ -89,12 +89,6 @@ fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
                 &blindings,
                 n,
             ).unwrap();
-
-            let value_commitments: Vec<_> = values
-                .iter()
-                .zip(blindings.iter())
-                .map(|(&v, &v_blinding)| pc_gens.commit(v.into(), v_blinding).compress())
-                .collect();
 
             b.iter(|| {
                 // Each proof creation requires a clean transcript.

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -4,7 +4,7 @@
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
 //! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
-use curve25519_dalek::ristretto::{RistrettoPoint, CompressedRistretto};
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 
 use generators::{BulletproofGens, PedersenGens};

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -4,7 +4,7 @@
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
 //! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
-use curve25519_dalek::ristretto::RistrettoPoint;
+use curve25519_dalek::ristretto::{RistrettoPoint, CompressedRistretto};
 use curve25519_dalek::scalar::Scalar;
 
 use generators::{BulletproofGens, PedersenGens};
@@ -12,7 +12,7 @@ use generators::{BulletproofGens, PedersenGens};
 /// A commitment to the bits of a party's value.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct BitCommitment {
-    pub(super) V_j: RistrettoPoint,
+    pub(super) V_j: CompressedRistretto,
     pub(super) A_j: RistrettoPoint,
     pub(super) S_j: RistrettoPoint,
 }
@@ -110,6 +110,8 @@ impl ProofShare {
             return Err(());
         }
 
+        let V_j = bit_commitment.V_j.decompress().ok_or(())?;
+
         let sum_of_powers_y = util::sum_of_powers(&y, n);
         let sum_of_powers_2 = util::sum_of_powers(&Scalar::from(2u64), n);
         let delta = (z - zz) * sum_of_powers_y * y_jn - z * zz * sum_of_powers_2 * z_j;
@@ -119,7 +121,7 @@ impl ProofShare {
                 .chain(iter::once(x * x))
                 .chain(iter::once(delta - self.t_x))
                 .chain(iter::once(-self.t_x_blinding)),
-            iter::once(&bit_commitment.V_j)
+            iter::once(&V_j)
                 .chain(iter::once(&poly_commitment.T_1_j))
                 .chain(iter::once(&poly_commitment.T_2_j))
                 .chain(iter::once(&pc_gens.B))

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -210,9 +210,6 @@ impl RangeProof {
         if values.len() != blindings.len() {
             return Err(ProofError::WrongNumBlindingFactors);
         }
-        if !(n == 8 || n == 16 || n == 32 || n == 64) {
-            return Err(ProofError::InvalidBitsize);
-        }
         if bp_gens.gens_capacity < n {
             return Err(ProofError::InvalidGeneratorsLength);
         }
@@ -233,6 +230,8 @@ impl RangeProof {
             .into_iter()
             .enumerate()
             .map(|(j, p)| p.assign_position(j))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
             .unzip();
 
         let (dealer, bit_challenge) = dealer.receive_bit_commitments(bit_commitments)?;
@@ -677,10 +676,10 @@ mod tests {
 
         let dealer = Dealer::new(&bp_gens, &pc_gens, &mut transcript, n, m).unwrap();
 
-        let (party0, bit_com0) = party0.assign_position(0);
-        let (party1, bit_com1) = party1.assign_position(1);
-        let (party2, bit_com2) = party2.assign_position(2);
-        let (party3, bit_com3) = party3.assign_position(3);
+        let (party0, bit_com0) = party0.assign_position(0).unwrap();
+        let (party1, bit_com1) = party1.assign_position(1).unwrap();
+        let (party2, bit_com2) = party2.assign_position(2).unwrap();
+        let (party3, bit_com3) = party3.assign_position(3).unwrap();
 
         let (dealer, bit_challenge) = dealer
             .receive_bit_commitments(vec![bit_com0, bit_com1, bit_com2, bit_com3])
@@ -737,7 +736,7 @@ mod tests {
 
         // Now do the protocol flow as normal....
 
-        let (party0, bit_com0) = party0.assign_position(0);
+        let (party0, bit_com0) = party0.assign_position(0).unwrap();
 
         let (dealer, bit_challenge) = dealer.receive_bit_commitments(vec![bit_com0]).unwrap();
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -133,7 +133,8 @@ impl RangeProof {
         v_blinding: &Scalar,
         n: usize,
     ) -> Result<(RangeProof, CompressedRistretto), ProofError> {
-        let (p, Vs) = RangeProof::prove_multiple(bp_gens, pc_gens, transcript, &[v], &[*v_blinding], n)?;
+        let (p, Vs) =
+            RangeProof::prove_multiple(bp_gens, pc_gens, transcript, &[v], &[*v_blinding], n)?;
         Ok((p, Vs[0]))
     }
 
@@ -245,7 +246,7 @@ impl RangeProof {
 
         let proof = dealer.receive_trusted_shares(&proof_shares)?;
 
-        Ok((proof,value_commitments))
+        Ok((proof, value_commitments))
     }
 
     /// Verifies a rangeproof for a given value commitment \\(V\\).

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -226,8 +226,7 @@ impl RangeProof {
             .into_iter()
             .unzip();
 
-        // XXX value commitments should be already compressed
-        let value_commitments: Vec<_> = bit_commitments.iter().map(|c| c.V_j.compress()).collect();
+        let value_commitments: Vec<_> = bit_commitments.iter().map(|c| c.V_j).collect();
 
         let (dealer, bit_challenge) = dealer.receive_bit_commitments(bit_commitments)?;
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -203,8 +203,6 @@ impl RangeProof {
         use self::dealer::*;
         use self::party::*;
 
-        // .zip silently truncates the longest iterator, so we need to check our lists
-        // have the same length.
         if values.len() != blindings.len() {
             return Err(ProofError::WrongNumBlindingFactors);
         }
@@ -221,10 +219,10 @@ impl RangeProof {
         let (parties, bit_commitments): (Vec<_>, Vec<_>) = parties
             .into_iter()
             .enumerate()
-            .map(|(j, p)| p.assign_position(j))
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .unzip();
+            .map(|(j, p)| {
+                p.assign_position(j)
+                    .expect("We already checked the parameters, so this should never happen")
+            }).unzip();
 
         let value_commitments: Vec<_> = bit_commitments.iter().map(|c| c.V_j).collect();
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -207,14 +207,10 @@ impl RangeProof {
         use self::dealer::*;
         use self::party::*;
 
+        // .zip silently truncates the longest iterator, so we need to check our lists
+        // have the same length.
         if values.len() != blindings.len() {
             return Err(ProofError::WrongNumBlindingFactors);
-        }
-        if bp_gens.gens_capacity < n {
-            return Err(ProofError::InvalidGeneratorsLength);
-        }
-        if bp_gens.party_capacity < values.len() {
-            return Err(ProofError::InvalidGeneratorsLength);
         }
 
         let dealer = Dealer::new(bp_gens, pc_gens, transcript, n, values.len())?;

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -10,7 +10,7 @@
 //! modules orchestrate the protocol execution, see the documentation
 //! in the [`aggregation`](::aggregation) module.
 
-use curve25519_dalek::ristretto::RistrettoPoint;
+use curve25519_dalek::ristretto::{RistrettoPoint, CompressedRistretto};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
 
@@ -41,7 +41,7 @@ impl Party {
             return Err(MPCError::InvalidGeneratorsLength);
         }
 
-        let V = pc_gens.commit(v.into(), v_blinding);
+        let V = pc_gens.commit(v.into(), v_blinding).compress();
 
         Ok(PartyAwaitingPosition {
             bp_gens,
@@ -61,7 +61,7 @@ pub struct PartyAwaitingPosition<'a> {
     n: usize,
     v: u64,
     v_blinding: Scalar,
-    V: RistrettoPoint,
+    V: CompressedRistretto,
 }
 
 impl<'a> PartyAwaitingPosition<'a> {

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -66,11 +66,14 @@ impl<'a> PartyAwaitingPosition<'a> {
     /// allowing the party to commit to the bits of their value.
     pub fn assign_position(
         self,
-        // XXX need to check that j is valid (in gens range)
         j: usize,
-    ) -> (PartyAwaitingBitChallenge<'a>, BitCommitment) {
+    ) -> Result<(PartyAwaitingBitChallenge<'a>, BitCommitment), MPCError> {
         // XXX use transcript RNG
         let mut rng = rand::thread_rng();
+
+        if self.bp_gens.gens_capacity <= j {
+            return Err(MPCError::InvalidGeneratorsLength);
+        }
 
         let bp_share = self.bp_gens.share(j);
 
@@ -119,7 +122,7 @@ impl<'a> PartyAwaitingPosition<'a> {
             s_L,
             s_R,
         };
-        (next_state, bit_commitment)
+        Ok((next_state, bit_commitment))
     }
 }
 

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -10,7 +10,7 @@
 //! modules orchestrate the protocol execution, see the documentation
 //! in the [`aggregation`](::aggregation) module.
 
-use curve25519_dalek::ristretto::{RistrettoPoint, CompressedRistretto};
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
 

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -74,7 +74,7 @@ impl<'a> PartyAwaitingPosition<'a> {
         // XXX use transcript RNG
         let mut rng = rand::thread_rng();
 
-        if self.bp_gens.gens_capacity <= j {
+        if self.bp_gens.party_capacity <= j {
             return Err(MPCError::InvalidGeneratorsLength);
         }
 

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -37,6 +37,9 @@ impl Party {
         if !(n == 8 || n == 16 || n == 32 || n == 64) {
             return Err(MPCError::InvalidBitsize);
         }
+        if bp_gens.gens_capacity < n {
+            return Err(MPCError::InvalidGeneratorsLength);
+        }
 
         let V = pc_gens.commit(v.into(), v_blinding);
 


### PR DESCRIPTION
This streamlines error handling between the Party/Dealer and the non-MPC RangeProof API. 
Also the rangeproof is returned together with value commitments as compressed points for convenience. These must be computed internally anyway, and the user is liberated from computing them themselves.