### PR TITLE
Clear secrets when dropped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = "1"
 serde_derive = "1"
 failure = "0.1"
 merlin = "0.4"
+clear_on_drop = "0.2.3"
 
 [dev-dependencies]
 hex = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@ extern crate digest;
 extern crate rand;
 extern crate sha3;
 
+extern crate clear_on_drop;
 extern crate curve25519_dalek;
 extern crate merlin;
 extern crate subtle;
-extern crate clear_on_drop;
 
 #[macro_use]
 extern crate serde_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate sha3;
 extern crate curve25519_dalek;
 extern crate merlin;
 extern crate subtle;
+extern crate clear_on_drop;
 
 #[macro_use]
 extern crate serde_derive;

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -19,6 +19,7 @@ use generators::{BulletproofGens, PedersenGens};
 use rand;
 use std::iter;
 use util;
+use clear_on_drop::clear::Clear;
 
 use super::messages::*;
 
@@ -129,6 +130,14 @@ impl<'a> PartyAwaitingPosition<'a> {
     }
 }
 
+/// Overwrite secrets with null bytes when they go out of scope.
+impl<'a> Drop for PartyAwaitingPosition<'a> {
+    fn drop(&mut self) {
+        self.v.clear();
+        self.v_blinding.clear();
+    }
+}
+
 /// A party which has committed to the bits of its value
 /// and is waiting for the aggregated value challenge from the dealer.
 pub struct PartyAwaitingBitChallenge<'a> {
@@ -206,6 +215,28 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
     }
 }
 
+/// Overwrite secrets with null bytes when they go out of scope.
+impl<'a> Drop for PartyAwaitingBitChallenge<'a> {
+    fn drop(&mut self) {
+        self.v.clear();
+        self.v_blinding.clear();
+        self.a_blinding.clear();
+        self.s_blinding.clear();
+
+        // Important: due to how ClearOnDrop auto-implements InitializableFromZeroed
+        // for T: Default, calling .clear() on Vec compiles, but does not
+        // clear the content. Instead, it only clears the Vec's header.
+        // Clearing the underlying buffer via a slice will do the job, but will
+        // keep the header as-is. But that's fine since the header has no secret data.
+        for e in self.s_L.iter_mut() {
+            e.clear();
+        }
+        for e in self.s_R.iter_mut() {
+            e.clear();
+        }
+    }
+}
+
 /// A party which has committed to their polynomial coefficents
 /// and is waiting for the polynomial challenge from the dealer.
 pub struct PartyAwaitingPolyChallenge {
@@ -250,5 +281,19 @@ impl PartyAwaitingPolyChallenge {
             l_vec,
             r_vec,
         })
+    }
+}
+
+/// Overwrite secrets with null bytes when they go out of scope.
+impl Drop for PartyAwaitingPolyChallenge {
+    fn drop(&mut self) {
+        self.v_blinding.clear();
+        self.a_blinding.clear();
+        self.s_blinding.clear();
+        self.t_1_blinding.clear();
+        self.t_2_blinding.clear();
+
+        // Note: polynomials r_poly, l_poly and t_poly
+        // are cleared within their own Drop impls.
     }
 }

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -226,8 +226,8 @@ impl<'a> Drop for PartyAwaitingBitChallenge<'a> {
         // Important: due to how ClearOnDrop auto-implements InitializableFromZeroed
         // for T: Default, calling .clear() on Vec compiles, but does not
         // clear the content. Instead, it only clears the Vec's header.
-        // Clearing the underlying buffer via a slice will do the job, but will
-        // keep the header as-is. But that's fine since the header has no secret data.
+        // Clearing the underlying buffer item-by-item will do the job, but will
+        // keep the header as-is, which is fine since the header does not contain secrets.
         for e in self.s_L.iter_mut() {
             e.clear();
         }

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -14,12 +14,12 @@ use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
 
+use clear_on_drop::clear::Clear;
 use errors::MPCError;
 use generators::{BulletproofGens, PedersenGens};
 use rand;
 use std::iter;
 use util;
-use clear_on_drop::clear::Clear;
 
 use super::messages::*;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,9 @@
 #![deny(missing_docs)]
 #![allow(non_snake_case)]
 
+use clear_on_drop::clear::Clear;
 use curve25519_dalek::scalar::Scalar;
 use inner_product_proof::inner_product;
-use clear_on_drop::clear::Clear;
 
 /// Represents a degree-1 vector polynomial \\(\mathbf{a} + \mathbf{b} \cdot x\\).
 pub struct VecPoly1(pub Vec<Scalar>, pub Vec<Scalar>);
@@ -253,19 +253,21 @@ mod tests {
             use core::mem;
             use core::slice;
 
-            unsafe {
-                slice::from_raw_parts(x.as_ptr() as *const u8, mem::size_of_val(x))
-            }
+            unsafe { slice::from_raw_parts(x.as_ptr() as *const u8, mem::size_of_val(x)) }
         }
 
-        assert_eq!(flat_slice(&v.as_slice()), &[0u8;64][..]);
+        assert_eq!(flat_slice(&v.as_slice()), &[0u8; 64][..]);
         assert_eq!(v[0], Scalar::zero());
         assert_eq!(v[1], Scalar::zero());
     }
 
     #[test]
     fn tuple_of_scalars_clear_on_drop() {
-        let mut v = Poly2(Scalar::from(24u64), Scalar::from(42u64), Scalar::from(255u64));
+        let mut v = Poly2(
+            Scalar::from(24u64),
+            Scalar::from(42u64),
+            Scalar::from(255u64),
+        );
 
         v.0.clear();
         v.1.clear();
@@ -275,12 +277,10 @@ mod tests {
             use core::mem;
             use core::slice;
 
-            unsafe {
-                slice::from_raw_parts(x as *const T as *const u8, mem::size_of_val(x))
-            }
+            unsafe { slice::from_raw_parts(x as *const T as *const u8, mem::size_of_val(x)) }
         }
 
-        assert_eq!(as_bytes(&v), &[0u8;96][..]);
+        assert_eq!(as_bytes(&v), &[0u8; 96][..]);
         assert_eq!(v.0, Scalar::zero());
         assert_eq!(v.1, Scalar::zero());
         assert_eq!(v.2, Scalar::zero());

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,7 @@
 
 use curve25519_dalek::scalar::Scalar;
 use inner_product_proof::inner_product;
+use clear_on_drop::clear::Clear;
 
 /// Represents a degree-1 vector polynomial \\(\mathbf{a} + \mathbf{b} \cdot x\\).
 pub struct VecPoly1(pub Vec<Scalar>, pub Vec<Scalar>);
@@ -84,6 +85,25 @@ impl VecPoly1 {
 impl Poly2 {
     pub fn eval(&self, x: Scalar) -> Scalar {
         self.0 + x * (self.1 + x * self.2)
+    }
+}
+
+impl Drop for VecPoly1 {
+    fn drop(&mut self) {
+        for e in self.0.iter_mut() {
+            e.clear();
+        }
+        for e in self.1.iter_mut() {
+            e.clear();
+        }
+    }
+}
+
+impl Drop for Poly2 {
+    fn drop(&mut self) {
+        self.0.clear();
+        self.1.clear();
+        self.2.clear();
     }
 }
 
@@ -219,5 +239,50 @@ mod tests {
         assert_eq!(sum_of_powers_slow(&x, 4), Scalar::from(1111u64));
         assert_eq!(sum_of_powers_slow(&x, 5), Scalar::from(11111u64));
         assert_eq!(sum_of_powers_slow(&x, 6), Scalar::from(111111u64));
+    }
+
+    #[test]
+    fn vec_of_scalars_clear_on_drop() {
+        let mut v = vec![Scalar::from(24u64), Scalar::from(42u64)];
+
+        for e in v.iter_mut() {
+            e.clear();
+        }
+
+        fn flat_slice<T>(x: &[T]) -> &[u8] {
+            use core::mem;
+            use core::slice;
+
+            unsafe {
+                slice::from_raw_parts(x.as_ptr() as *const u8, mem::size_of_val(x))
+            }
+        }
+
+        assert_eq!(flat_slice(&v.as_slice()), &[0u8;64][..]);
+        assert_eq!(v[0], Scalar::zero());
+        assert_eq!(v[1], Scalar::zero());
+    }
+
+    #[test]
+    fn tuple_of_scalars_clear_on_drop() {
+        let mut v = Poly2(Scalar::from(24u64), Scalar::from(42u64), Scalar::from(255u64));
+
+        v.0.clear();
+        v.1.clear();
+        v.2.clear();
+
+        fn as_bytes<T>(x: &T) -> &[u8] {
+            use core::mem;
+            use core::slice;
+
+            unsafe {
+                slice::from_raw_parts(x as *const T as *const u8, mem::size_of_val(x))
+            }
+        }
+
+        assert_eq!(as_bytes(&v), &[0u8;96][..]);
+        assert_eq!(v.0, Scalar::zero());
+        assert_eq!(v.1, Scalar::zero());
+        assert_eq!(v.2, Scalar::zero());
     }
 }


### PR DESCRIPTION
In the RangeProof implementation, each `Party` holds various secrets at different stages of the protocol. When the corresponding structure is consumed & dropped, the secrets must be cleared from memory before they can be part of uninitialized state of some other data.

This adds clearing of the secret data only, and a couple of tests that show that the method for clearing tuples and vectors actually works.