### PR TITLE
Efficient padding of the constraint system to a power-of-two multipliers

### DIFF
--- a/docs/cs-proof.md
+++ b/docs/cs-proof.md
@@ -562,7 +562,7 @@ S   &= \widetilde{B} \cdot \tilde{s} + \langle \mathbf{G} , \mathbf{s}\_L \rangl
 
 The prover forms these commitments, and sends them to the verifier.
 
-For reference, here are the equations for \\({\mathbf{l}}(x)\\) and transmuted \\({\mathbf{r}}(x)\\):
+For reference, here are the equations for \\({\mathbf{l}}(x)\\), and \\({\mathbf{r}}(x)\\) multiplied by \\(\mathbf{y}^{-n}\\):
 
 \\[
 \begin{aligned}

--- a/docs/cs-proof.md
+++ b/docs/cs-proof.md
@@ -621,32 +621,43 @@ and related commitments before we can use the inner product argument.
 Our goal is to translate the _padding of the constraint system_ into the _padding of proof data_,
 so we can keep the constraint system small and perform less computations in proving and verification.
 
+We will use the following notation for the padding:
+
+\\[
+\begin{aligned}
+                           n^{+} &= 2^{\lceil \log_2 n \rceil} \\\\
+                      {\Delta n} &= n^{+} - n \\\\
+           \mathbf{0}^{\Delta n} &= [0,...,0] \\\\
+  \mathbf{0}^{q \times \Delta n} &= [[0,...,0], ..., [0,...,0]]
+\end{aligned}
+\\]
+
 We start by padding the entire constraint system:
 multipliers are padded with all-zero assignments \\(a\_{L,j}, a\_{R,j}, a\_{O,j}\\),
 all-zero blinding factors \\(s\_{L,j}, s\_{R,j}\\),
 and all-zero weights \\(W\_{R,i,j}, W\_{L,i,j}, W\_{O,i,j}\\),
-for all constraints \\(i \in [0, q)\\) and all additional multipliers \\(j \in [n,n')\\):
+for all constraints \\(i \in [0, q)\\) and all additional multipliers \\(j \in [n,n^{+})\\):
 
 \\[
 \begin{aligned}
-\mathbf{a}\_L^{+} &= \mathbf{a}\_L \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
-\mathbf{a}\_R^{+} &= \mathbf{a}\_R \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
-\mathbf{a}\_O^{+} &= \mathbf{a}\_O \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
-\mathbf{s}\_L^{+} &= \mathbf{s}\_L \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
-\mathbf{s}\_R^{+} &= \mathbf{s}\_R \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
-\mathbf{W}\_L^{+} &= \mathbf{W}\_L \hspace{0.1cm} || \hspace{0.1cm} [[0,...,0],...,[0,...,0]] \\\\
-\mathbf{W}\_R^{+} &= \mathbf{W}\_R \hspace{0.1cm} || \hspace{0.1cm} [[0,...,0],...,[0,...,0]] \\\\
-\mathbf{W}\_O^{+} &= \mathbf{W}\_O \hspace{0.1cm} || \hspace{0.1cm} [[0,...,0],...,[0,...,0]] \\\\
+\mathbf{a}\_L^{+} &= \mathbf{a}\_L \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
+\mathbf{a}\_R^{+} &= \mathbf{a}\_R \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
+\mathbf{a}\_O^{+} &= \mathbf{a}\_O \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
+\mathbf{s}\_L^{+} &= \mathbf{s}\_L \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
+\mathbf{s}\_R^{+} &= \mathbf{s}\_R \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
+\mathbf{W}\_L^{+} &= \mathbf{W}\_L \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{q \times \Delta n} \\\\
+\mathbf{W}\_R^{+} &= \mathbf{W}\_R \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{q \times \Delta n} \\\\
+\mathbf{W}\_O^{+} &= \mathbf{W}\_O \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{q \times \Delta n} \\\\
 \end{aligned}
 \\]
 
-As a result, the vectors of generators \\(\mathbf{G},\mathbf{H}\\) and challenges \\(\mathbf{y}^n\\) are extended:
+As a result, we have to take larger slices of the vectors of generators \\(\mathbf{G},\mathbf{H}\\) and more powers of the challenge \\(y\\):
 
 \\[
 \begin{aligned}
 \mathbf{G}^{+}     &= \mathbf{G}   \hspace{0.1cm} || \hspace{0.1cm} [G_n,...,G_{n^{+}-1}] \\\\
 \mathbf{H}^{+}     &= \mathbf{H}   \hspace{0.1cm} || \hspace{0.1cm} [H_n,...,H_{n^{+}-1}] \\\\
-\mathbf{y}^{n^{+}} &= \mathbf{y}^n \hspace{0.1cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \\\\
+\mathbf{y}^{n^{+}} &= \mathbf{y}^n \hspace{0.1cm} || \hspace{0.1cm} y^n \mathbf{y}^{\Delta n} \\\\
 \end{aligned}
 \\]
 
@@ -654,19 +665,31 @@ The low-level variables are padded with zeroes, so their commitments remain unch
 
 \\[
 \begin{aligned}
-A_I^{+} &= \widetilde{B} \cdot \tilde{a} + \langle \mathbf{G}^{+} , \mathbf{a}\_L^{+} \rangle + \langle \mathbf{H}^{+}, \mathbf{a}\_R^{+} \rangle &{}={}& A_I \\\\
-A_O^{+} &= \widetilde{B} \cdot \tilde{o} + \langle \mathbf{G}^{+} , \mathbf{a}\_O^{+} \rangle                                                     &{}={}& A_O \\\\
-S^{+}   &= \widetilde{B} \cdot \tilde{s} + \langle \mathbf{G}^{+} , \mathbf{s}\_L^{+} \rangle + \langle \mathbf{H}^{+}, \mathbf{s}\_R^{+} \rangle &{}={}& S
+A_I^{+} &= \widetilde{B} \cdot \tilde{a} + \langle \mathbf{G}^{+}, \mathbf{a}\_L^{+} \rangle + \langle \mathbf{H}^{+}, \mathbf{a}\_R^{+} \rangle \\\\
+        &= \widetilde{B} \cdot \tilde{a} + \langle \mathbf{G}, \mathbf{a}\_L \rangle + \langle \mathbf{H}, \mathbf{a}\_R \rangle +
+           \langle [G_n, ..., G_{n^{+}-1}], \mathbf{0}^{\Delta n} \rangle + \langle [H_n, ..., H_{n^{+}-1}], \mathbf{0}^{\Delta n} \rangle \\\\
+		&= \widetilde{B} \cdot \tilde{a} + \langle \mathbf{G}, \mathbf{a}\_L \rangle + \langle \mathbf{H}, \mathbf{a}\_R \rangle + 
+		   0 \\\\
+        &= A_I \\\\
 \end{aligned}
 \\]
 
-The flattened weight vectors \\(\mathbf{w}\_{L,R,O}\\) are padded with \\((n^{+} - n)\\) zeroes
+Similarly, \\(A_O\\) and \\(S\\) are unchanged:
+
+\\[
+\begin{aligned}
+A_O^{+} &= A_O \\\\
+S^{+}   &= S
+\end{aligned}
+\\]
+
+The flattened weight vectors \\(\mathbf{w}\_{L,R,O}\\) are padded with \\(\Delta n\\) zeroes
 because the corresponding weights are padded with zeroes:
 \\[
 \begin{aligned}
-\mathbf{w}\_L^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_L^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_L) || (z \mathbf{z}^q \cdot [0,...,0]) &{}={}& \mathbf{w}\_L || [0,...,0], \\\\
-\mathbf{w}\_R^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_R^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_R) || (z \mathbf{z}^q \cdot [0,...,0]) &{}={}& \mathbf{w}\_R || [0,...,0], \\\\
-\mathbf{w}\_O^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_O^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_O) || (z \mathbf{z}^q \cdot [0,...,0]) &{}={}& \mathbf{w}\_O || [0,...,0]. \\\\
+\mathbf{w}\_L^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_L^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_L) || (z \mathbf{z}^q \cdot \mathbf{0}^{\Delta n}) &{}={}& \mathbf{w}\_L || \mathbf{0}^{\Delta n}, \\\\
+\mathbf{w}\_R^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_R^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_R) || (z \mathbf{z}^q \cdot \mathbf{0}^{\Delta n}) &{}={}& \mathbf{w}\_R || \mathbf{0}^{\Delta n}, \\\\
+\mathbf{w}\_O^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_O^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_O) || (z \mathbf{z}^q \cdot \mathbf{0}^{\Delta n}) &{}={}& \mathbf{w}\_O || \mathbf{0}^{\Delta n}. \\\\
 \end{aligned}
 \\]
 
@@ -675,26 +698,34 @@ The \\(\delta(y,z)\\) remains unchanged because the padding weights are zeroes:
 \\[
 \begin{aligned}
 \delta(y, z)^{+} &= \langle \mathbf{y}^{-n^{+}} \circ \mathbf{w}\_R^{+}, \mathbf{w}\_L^{+} \rangle \\\\
-                 &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_R, \mathbf{w}\_L \rangle      +     \langle [y^n,...,y^{n^{+}-1}] \circ [0,...,0], [0,...,0] \rangle \\\\
+                 &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_R, \mathbf{w}\_L \rangle      +     \langle [y^n,...,y^{n^{+}-1}] \circ \mathbf{0}^{\Delta n}, \mathbf{0}^{\Delta n} \rangle \\\\
                  &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_R, \mathbf{w}\_L \rangle      +     0 \\\\
                  &= \delta(y, z)
 \end{aligned}
 \\]
 
-Vector polynomials \\(\mathbf{l}(x)\\) is padded with zeroes and \\(\mathbf{r}(x)\\) is padded with additional powers of \\(y\\) in its 0th term:
+Vector polynomial \\(\mathbf{l}(x)\\) is padded with zeroes:
 
 \\[
 \begin{aligned}
 \mathbf{l}(x)^{+} &= \mathbf{a}\_L^{+} \cdot x + \mathbf{s}\_L^{+} \cdot x^3 + \mathbf{y}^{-n^{+}} \circ \mathbf{w}\_R^{+} \cdot x + \mathbf{a}\_O^{+} \cdot x^2 \\\\
                   &= \mathbf{a}\_L \cdot x + \mathbf{s}\_L \cdot x^3 + \mathbf{y}^{-n} \circ \mathbf{w}\_R \cdot x + \mathbf{a}\_O \cdot x^2 \\\\
-                  &  \hspace{0.5cm} || \hspace{0.1cm} [0,...,0] \cdot x + [0,...,0] \cdot x^3 + [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x + [0,...,0] \cdot x^2 \\\\
-                  &= \mathbf{l}(x) || [0,...,0] \\\\
-\mathbf{r}(x)^{+} &= \mathbf{y}^{n^{+}} \circ \mathbf{a}\_R^{+} \cdot x + \mathbf{y}^{n^{+}} \circ \mathbf{s}\_R^{+} \cdot x^3 + \mathbf{w}\_L^{+} \cdot x - \mathbf{y}^{n^{+}} + \mathbf{w}\_O^{+} \\\\
-                  &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O \\\\
-                  &  \hspace{0.5cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x + [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x^3 + [0,...,0] \cdot x - [y^n,...,y^{n^{+}-1}] + [0,...,0] \\\\
-                  &= \mathbf{r}(x) || [-y^n,...,-y^{n^{+}-1}]
+                  &  \hspace{0.5cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \cdot x + \mathbf{0}^{\Delta n} \cdot x^3 + y^n \mathbf{y}^{\Delta n} \circ \mathbf{0}^{\Delta n} \cdot x + \mathbf{0}^{\Delta n} \cdot x^2 \\\\
+                  &= \mathbf{l}(x) || \mathbf{0}^{\Delta n} \\\\
 \end{aligned}
 \\]
+
+Vector polynomial \\(\mathbf{r}(x)\\) is padded with additional powers of \\(y\\):
+
+\\[
+\begin{aligned}
+\mathbf{r}(x)^{+} &= \mathbf{y}^{n^{+}} \circ \mathbf{a}\_R^{+} \cdot x + \mathbf{y}^{n^{+}} \circ \mathbf{s}\_R^{+} \cdot x^3 + \mathbf{w}\_L^{+} \cdot x - \mathbf{y}^{n^{+}} + \mathbf{w}\_O^{+} \\\\
+                  &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O \\\\
+                  &  \hspace{0.5cm} || \hspace{0.1cm} y^n \mathbf{y}^{\Delta n} \circ \mathbf{0}^{\Delta n} \cdot x + y^n \mathbf{y}^{\Delta n} \circ \mathbf{0}^{\Delta n} \cdot x^3 + \mathbf{0}^{\Delta n} \cdot x - y^n \mathbf{y}^{\Delta n} + \mathbf{0}^{\Delta n} \\\\
+                  &= \mathbf{r}(x) || y^n \mathbf{y}^{\Delta n}
+\end{aligned}
+\\]
+
 
 The commitments to these vector polynomials are also padded (\\(W\_{L,R,O}\\) remain unchanged because the weights are padded with zeroes):
 
@@ -710,7 +741,7 @@ The inner product \\(t(x)\\) remains unchanged because the non-zero padding in t
 \\[
 \begin{aligned}
 t(x)^{+} &= {\langle {\mathbf{l}}(x)^{+}, {\mathbf{r}}(x)^{+} \rangle} \\\\
-         &= {\langle {\mathbf{l}}(x), {\mathbf{r}}(x) \rangle} + {\langle [0,...,0], [-y^n,...,-y^{n^{+}-1}] \rangle} \\\\
+         &= {\langle {\mathbf{l}}(x), {\mathbf{r}}(x) \rangle} + {\langle \mathbf{0}^{\Delta n}, y^n \mathbf{y}^{\Delta n} \rangle} \\\\
          &= {\langle {\mathbf{l}}(x), {\mathbf{r}}(x) \rangle} + 0 \\\\
          &= t(x)
 \end{aligned}
@@ -816,10 +847,17 @@ The prover evaluates polynomials \\(\mathbf{l}(x), \mathbf{r}(x)\\) and
 \\[
 \begin{aligned}
              n^{+} &= 2^{\lceil \log_2 n \rceil} \\\\
-\mathbf{l}^{+}     &= \mathbf{l}(x) \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
-\mathbf{r}^{+}     &= \mathbf{r}(x) \hspace{0.1cm} || \hspace{0.1cm} [-y^n,...,-y^{n^{+}-1}] \\\\
+\mathbf{l}^{+}     &= \mathbf{l}(x) \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
+\mathbf{r}^{+}     &= \mathbf{r}(x) \hspace{0.1cm} || \hspace{0.1cm} y^n \mathbf{y}^{\Delta n}
+\end{aligned}
+\\]
+
+The prover also takes a larger slice of the generators \\(\mathbf{G}, \mathbf{H}\\):
+
+\\[
+\begin{aligned}
 \mathbf{G}^{+}     &= \mathbf{G}    \hspace{0.1cm} || \hspace{0.1cm} [G_n,...,G_{n^{+}-1}] \\\\
-{\mathbf{H}'}^{+}  &= \mathbf{H}'   \hspace{0.1cm} || \hspace{0.1cm} \Big( [y^{-n},...,y^{-(n^{+}-1)}] \circ [H_n,...,H_{n^{+}-1}] \Big) \\\\
+{\mathbf{H}'}^{+}  &= \mathbf{H}'   \hspace{0.1cm} || \hspace{0.1cm} \Big( y^n \mathbf{y}^{\Delta n} \circ [H_n,...,H_{n^{+}-1}] \Big) \\\\
 \end{aligned}
 \\]
 
@@ -874,11 +912,13 @@ The verifier flattens constraints:
 \\]
 where each of \\(\mathbf{w}\_L, \mathbf{w}\_R, \mathbf{w}\_O\\) has length \\(n\\) and \\(\mathbf{w}\_V\\) has length \\(m\\).
 
-The verifier [pads](#padding-mathbflx-and-mathbfrx-for-the-inner-product-proof) the generators \\(\mathbf{G},\mathbf{H}\\) and challenges \\(\mathbf{y}^n\\) to a power-of-two \\(n^{+}\\):
+The verifier [pads the proof data](#padding-mathbflx-and-mathbfrx-for-the-inner-product-proof)
+by taking a larger slice of the generators \\(\mathbf{G},\mathbf{H}\\) and more powers of challenges \\(\mathbf{y}^n\\) to a power-of-two \\(n^{+}\\):
 
 \\[
 \begin{aligned}
              n^{+} &= 2^{\lceil \log_2 n \rceil} \\\\
+          \Delta n &= n^{+} - n \\\\
 \mathbf{G}^{+}     &= \mathbf{G}   \hspace{0.1cm} || \hspace{0.1cm} [G_n,...,G_{n^{+}-1}] \\\\
 \mathbf{H}^{+}     &= \mathbf{H}   \hspace{0.1cm} || \hspace{0.1cm} [H_n,...,H_{n^{+}-1}] \\\\
 \mathbf{y}^{n^{+}} &= \mathbf{y}^n \hspace{0.1cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \\\\
@@ -949,8 +989,8 @@ Finally, verifier groups all scalars by each point and performs a single multisc
                       + & \quad \sum\_{i = 1,3,4,5,6} r x^i T\_{i} \\\\
                       + & \quad \Big(w \big(t(x) - ab\big) + r \big(x^2 (w\_c + \delta(y,z)) - t(x)\big) \Big) \cdot B \\\\
                       + & \quad (-{\widetilde{e}} - r{\tilde{t}}(x)) \cdot \widetilde{B} \\\\
-                      + & \quad {\langle \big( x \mathbf{y}^{-n^{+}} \circ \mathbf{w}\_R \big) || [0,...,0] - a\mathbf{s}, \mathbf{G}^{+} \rangle}\\\\
-                      + & \quad {\langle -\mathbf{1} + \mathbf{y}^{-n^{+}} \circ \big( (x \mathbf{w}\_L + \mathbf{w}\_O) || [0,...,0] - (b /{\mathbf{s}}) \big), \mathbf{H}^{+} \rangle}\\\\
+                      + & \quad {\langle \big( x \mathbf{y}^{-n} \circ \mathbf{w}\_R \big) || \mathbf{0}^{\Delta n} - a\mathbf{s}, \mathbf{G}^{+} \rangle}\\\\
+                      + & \quad {\langle -\mathbf{1} + \mathbf{y}^{-n^{+}} \circ \big( (x \mathbf{w}\_L + \mathbf{w}\_O) || \mathbf{0}^{\Delta n} - (b /{\mathbf{s}}) \big), \mathbf{H}^{+} \rangle}\\\\
                       + & \quad {\langle [u_{1}^2,    \dots, u_{k}^2    ], [L_1, \dots, L_{k}] \rangle}\\\\
                       + & \quad {\langle [u_{1}^{-2}, \dots, u_{k}^{-2} ], [R_1, \dots, R_{k}] \rangle}
 \end{aligned}

--- a/docs/cs-proof.md
+++ b/docs/cs-proof.md
@@ -690,13 +690,24 @@ Finally, \\(\mathbf{l}(x)\\) is padded with zeroes and \\(\mathbf{r}(x)\\) is pa
                   &  \hspace{0.5cm} || \hspace{0.1cm} [0,...,0] \cdot x + [0,...,0] \cdot x^3 + [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x + [0,...,0] \cdot x^2 \\\\
                   &= \mathbf{l}(x) || [0,...,0] \\\\
 \mathbf{r}(x)^{+} &= \mathbf{y}^{n^{+}} \circ \mathbf{a}\_R^{+} \cdot x + \mathbf{y}^{n^{+}} \circ \mathbf{s}\_R^{+} \cdot x^3 + \mathbf{w}\_L^{+} \cdot x - \mathbf{y}^{n^{+}} + \mathbf{w}\_O^{+} \\\\
-				  &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O \\\\
-				  &  \hspace{0.5cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x + [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x^3 + [0,...,0] \cdot x - [y^n,...,y^{n^{+}-1}] + [0,...,0] \\\\
-				  &= \mathbf{r}(x) || [-y^n,...,-y^{n^{+}-1}]
+                  &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O \\\\
+                  &  \hspace{0.5cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x + [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x^3 + [0,...,0] \cdot x - [y^n,...,y^{n^{+}-1}] + [0,...,0] \\\\
+                  &= \mathbf{r}(x) || [-y^n,...,-y^{n^{+}-1}]
 \end{aligned}
 \\]
 
+The inner product \\(t(x)\\) remains unchanged because the non-zero padding in the right vector gets multiplied with the zero padding in the left vector:
 
+\\[
+\begin{aligned}
+t(x)^{+} &= {\langle {\mathbf{l}}(x)^{+}, {\mathbf{r}}(x)^{+} \rangle} \\\\
+         &= {\langle {\mathbf{l}}(x), {\mathbf{r}}(x) \rangle} + {\langle [0,...,0], [-y^n,...,-y^{n^{+}-1}] \rangle} \\\\
+         &= {\langle {\mathbf{l}}(x), {\mathbf{r}}(x) \rangle} + 0 \\\\
+         &= t(x)
+\end{aligned}
+\\]
+
+This implies that the terms \\(t\_{0, 1, 2, 3, 4, 5, 6}\\) also remain unchanged.
 
 Prover’s algorithm
 ------------------
@@ -789,15 +800,28 @@ The prover adds \\(t(x), {\tilde{t}}(x), {\tilde{e}}\\) to the protocol transcri
 	Q \gets  w \cdot B
 \\]
 
-The prover evaluates polynomials \\(\mathbf{l}(x), \mathbf{r}(x)\\) and performs the [inner product argument](../inner_product_proof/index.html) to prove the relation:
+The prover evaluates polynomials \\(\mathbf{l}(x), \mathbf{r}(x)\\) and
+[pads them to the next power of two](#padding-mathbflx-and-mathbfrx-for-the-inner-product-proof) \\(n \rightarrow n^{+}\\):
+
+\\[
+\begin{aligned}
+             n^{+} &= 2^{\lceil \log_2 n \rceil} \\\\
+\mathbf{l}^{+}     &= \mathbf{l}(x) \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
+\mathbf{r}^{+}     &= \mathbf{r}(x) \hspace{0.1cm} || \hspace{0.1cm} [-y^n,...,-y^{n^{+}-1}] \\\\
+\mathbf{G}^{+}     &= \mathbf{G}    \hspace{0.1cm} || \hspace{0.1cm} [G_n,...,G_{n^{+}-1}] \\\\
+{\mathbf{H}'}^{+}  &= \mathbf{H}'   \hspace{0.1cm} || \hspace{0.1cm} \Big( [y^{-n},...,y^{-(n^{+}-1)}] \circ [H_n,...,H_{n^{+}-1}] \Big) \\\\
+\end{aligned}
+\\]
+
+Finally, the prover performs the [inner product argument](../inner_product_proof/index.html) to prove the relation:
 \\[
 \operatorname{PK}\left\\{
-  ({\mathbf{G}}, {\mathbf{H}}' \in {\mathbb G}^{n}, P', Q \in {\mathbb G}; {\mathbf{l}}, {\mathbf{r}} \in {\mathbb Z\_p}^{n})
-  : P' = {\langle {\mathbf{l}}, {\mathbf{G}} \rangle} + {\langle {\mathbf{r}}, {\mathbf{H}}' \rangle} + {\langle {\mathbf{l}}, {\mathbf{r}} \rangle} Q
+  (\mathbf{G}^{+}, {\mathbf{H}'}^{+} \in {\mathbb G}^{n^{+}}, P', Q \in {\mathbb G}; \mathbf{l}^{+}, \mathbf{r}^{+} \in {\mathbb Z\_p}^{n^{+}})
+  : P' = {\langle \mathbf{l}^{+}, \mathbf{G}^{+} \rangle} + {\langle \mathbf{r}^{+}, {\mathbf{H}'}^{+} \rangle} + {\langle \mathbf{l}^{+}, \mathbf{r}^{+} \rangle} Q
 \right\\}
-\\] where \\({\mathbf{H}}' = {\mathbf{y}}^{-n} \circ {\mathbf{H}}\\).
+\\] where \\({\mathbf{H}'}^{+} = {\mathbf{y}}^{-n^{+}} \circ \mathbf{H}^{+}\\).
 
-The result of the inner product proof is a list of \\(2k\\) points and \\(2\\) scalars, where \\(k = \log_2(n)\\): \\(\\{L\_k, R\_k, \\dots, L\_1, R\_1, a, b\\}\\).
+The result of the inner product proof is a list of \\(2k\\) points and \\(2\\) scalars, where \\(k = \lceil \log_2(n) \rceil\\): \\(\\{L\_k, R\_k, \\dots, L\_1, R\_1, a, b\\}\\).
 
 The complete proof consists of \\(13+2k\\) 32-byte elements:
 \\[
@@ -810,7 +834,7 @@ Verifier’s algorithm
 --------------------
 
 The input to the verifier is the aggregated proof, which contains the \\(m\\) value commitments \\(V_{(j)}\\),
-and \\(32 \cdot (13 + 2 k)\\) bytes of the proof data where \\(k = \log_2(n)\\) and \\(n\\) is a number of [multiplication gates](#multiplication-gates):
+and \\(32 \cdot (13 + 2 k)\\) bytes of the proof data where \\(k = \lceil \log_2(n) \rceil\\) and \\(n\\) is a number of [multiplication gates](#multiplication-gates):
 
 \\[
   \\{A\_I, A\_O, S, T\_1, T\_3, T\_4, T\_5, T\_6, t(x), {\tilde{t}}(x), \tilde{e}, L\_k, R\_k, \\dots, L\_1, R\_1, a, b\\}

--- a/docs/cs-proof.md
+++ b/docs/cs-proof.md
@@ -911,7 +911,7 @@ The verifier flattens constraints:
 where each of \\(\mathbf{w}\_L, \mathbf{w}\_R, \mathbf{w}\_O\\) has length \\(n\\) and \\(\mathbf{w}\_V\\) has length \\(m\\).
 
 The verifier [pads the proof data](#padding-mathbflx-and-mathbfrx-for-the-inner-product-proof)
-by taking a larger slice of the generators \\(\mathbf{G},\mathbf{H}\\) and more powers of challenges \\(\mathbf{y}^n\\) to a power-of-two \\(n^{+}\\):
+by taking a larger slice of the generators \\(\mathbf{G},\mathbf{H}\\) and more powers of challenges \\(y\\) up to \\((n^{+}-1)\\):
 
 \\[
 \begin{aligned}

--- a/docs/cs-proof.md
+++ b/docs/cs-proof.md
@@ -713,14 +713,14 @@ Vector polynomial \\(\mathbf{l}(x)\\) is padded with zeroes:
 \end{aligned}
 \\]
 
-Vector polynomial \\(\mathbf{r}(x)\\) is padded with additional powers of \\(y\\):
+Vector polynomial \\(\mathbf{r}(x)\\) is padded with additional (negated) powers of \\(y\\):
 
 \\[
 \begin{aligned}
 \mathbf{r}(x)^{+} &= \mathbf{y}^{n^{+}} \circ \mathbf{a}\_R^{+} \cdot x + \mathbf{y}^{n^{+}} \circ \mathbf{s}\_R^{+} \cdot x^3 + \mathbf{w}\_L^{+} \cdot x - \mathbf{y}^{n^{+}} + \mathbf{w}\_O^{+} \\\\
                   &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O \\\\
                   &  \hspace{0.5cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \circ \mathbf{0} \cdot x + [y^n,...,y^{n^{+}-1}] \circ \mathbf{0} \cdot x^3 + \mathbf{0} \cdot x - [y^n,...,y^{n^{+}-1}] + \mathbf{0} \\\\
-                  &= \mathbf{r}(x) || [y^n,...,y^{n^{+}-1}]
+                  &= \mathbf{r}(x) || [-y^n,...,-y^{n^{+}-1}]
 \end{aligned}
 \\]
 
@@ -846,7 +846,7 @@ The prover evaluates polynomials \\(\mathbf{l}(x), \mathbf{r}(x)\\) and
 \begin{aligned}
              n^{+} &= 2^{\lceil \log_2 n \rceil} \\\\
 \mathbf{l}^{+}     &= \mathbf{l}(x) \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0} \\\\
-\mathbf{r}^{+}     &= \mathbf{r}(x) \hspace{0.1cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}]
+\mathbf{r}^{+}     &= \mathbf{r}(x) \hspace{0.1cm} || \hspace{0.1cm} [-y^n,...,-y^{n^{+}-1}]
 \end{aligned}
 \\]
 

--- a/docs/cs-proof.md
+++ b/docs/cs-proof.md
@@ -421,9 +421,9 @@ which represent the left and right sides of the input to the inner-product equat
 \\[
 \begin{aligned}
   {\mathbf{l}}(x) &= (\mathbf{a}\_L + \mathbf{s}\_L \cdot x^2) \cdot x + \mathbf{y}^{-n} \circ \mathbf{w}\_R \cdot x + \mathbf{a}\_O \cdot x^2 \\\\
-  &= \mathbf{a}\_L \cdot x + \mathbf{s}\_L \cdot x^3 + \mathbf{y}^{-n} \circ \mathbf{w}\_R \cdot x + \mathbf{a}\_O \cdot x^2 \\\\
+                  &= \mathbf{a}\_L \cdot x + \mathbf{s}\_L \cdot x^3 + \mathbf{y}^{-n} \circ \mathbf{w}\_R \cdot x + \mathbf{a}\_O \cdot x^2 \\\\
   {\mathbf{r}}(x) &= \mathbf{y}^n \circ (\mathbf{a}\_R + \mathbf{s}\_R \cdot x^2) \cdot x + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O \\\\
-  &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O
+                  &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O
 \end{aligned}
 \\]
 
@@ -556,18 +556,18 @@ A_O &= \widetilde{B} \cdot \tilde{o} + \langle \mathbf{G} , \mathbf{a}\_O \rangl
 W_L &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_L, \mathbf{H} \rangle \\\\
 W_R &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_R, \mathbf{G} \rangle \\\\
 W_O &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_O, \mathbf{H} \rangle \\\\
-S &= \widetilde{B} \cdot \tilde{s} + \langle \mathbf{G} , \mathbf{s}\_L \rangle + \langle \mathbf{H}, \mathbf{s}\_R \rangle
+S   &= \widetilde{B} \cdot \tilde{s} + \langle \mathbf{G} , \mathbf{s}\_L \rangle + \langle \mathbf{H}, \mathbf{s}\_R \rangle
 \end{aligned}
 \\]
 
 The prover forms these commitments, and sends them to the verifier.
 
-For reference, here are the equations for \\({\mathbf{l}}(x)\\) and \\({\mathbf{r}}(x)\\):
+For reference, here are the equations for \\({\mathbf{l}}(x)\\) and transmuted \\({\mathbf{r}}(x)\\):
 
 \\[
 \begin{aligned}
-  {\mathbf{l}}(x)  &= \mathbf{a}\_L \cdot x + \mathbf{s}\_L \cdot x^3 + \mathbf{y}^{-n} \circ \mathbf{w}\_R \cdot x + \mathbf{a}\_O \cdot x^2 \\\\
-  {\mathbf{r}}(x)  &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O
+                        \mathbf{l}(x)  &= \mathbf{a}\_L \cdot x + \mathbf{s}\_L \cdot x^3 + \mathbf{y}^{-n} \circ \mathbf{w}\_R \cdot x + \mathbf{a}\_O \cdot x^2 \\\\
+  \mathbf{y}^{-n} \circ \mathbf{r}(x)  &= \mathbf{a}\_R \cdot x + \mathbf{s}\_R \cdot x^3 + \mathbf{y}^{-n} \circ \mathbf{w}\_L \cdot x - \mathbf{1}^n + \mathbf{y}^{-n} \circ \mathbf{w}\_O
 \end{aligned}
 \\]
 
@@ -607,6 +607,94 @@ if the prover is honest, this is
 so the verifier uses \\(P\\) and \\(t(x)\\) as inputs to the [inner product protocol](../notes/index.html#inner-product-proof)
 to prove that
 \\(t(x) = {\langle {\mathbf{l}}(x), {\mathbf{r}}(x) \rangle}\\).
+
+
+Padding \\(\mathbf{l}(x)\\) and \\(\mathbf{r}(x)\\) for the inner product proof
+-------------------------------------------------------------------------------
+
+The above discussion did not have restrictions on the value \\(n\\).
+However, the [inner product argument](../notes/index.html#inner-product-proof)
+requires the input vectors to have power-of-two elements: \\(n^{+} = 2^k\\).
+To resolve this mismatch, we need to specify how to pad vectors \\(\mathbf{l}(x), \mathbf{r}(x)\\)
+and related commitments before we can use the inner product argument.
+
+Our goal is to translate the _padding of the constraint system_ into the _padding of proof data_,
+so we can keep the constraint system small and perform less computations in proving and verification.
+
+We start by padding the entire constraint system:
+multipliers are padded with all-zero assignments \\(a\_{L,j}, a\_{R,j}, a\_{O,j}\\),
+all-zero blinding factors \\(s\_{L,j}, s\_{R,j}\\),
+and all-zero weights \\(W\_{R,i,j}, W\_{L,i,j}, W\_{O,i,j}\\),
+for all constraints \\(i \in [0, q)\\) and all additional multipliers \\(j \in [n,n')\\):
+
+\\[
+\begin{aligned}
+\mathbf{a}\_L^{+} &= \mathbf{a}\_L \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
+\mathbf{a}\_R^{+} &= \mathbf{a}\_R \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
+\mathbf{a}\_O^{+} &= \mathbf{a}\_O \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
+\mathbf{s}\_L^{+} &= \mathbf{s}\_L \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
+\mathbf{s}\_R^{+} &= \mathbf{s}\_R \hspace{0.1cm} || \hspace{0.1cm} [0,...,0] \\\\
+\mathbf{W}\_L^{+} &= \mathbf{W}\_L \hspace{0.1cm} || \hspace{0.1cm} [[0,...,0],...,[0,...,0]] \\\\
+\mathbf{W}\_R^{+} &= \mathbf{W}\_R \hspace{0.1cm} || \hspace{0.1cm} [[0,...,0],...,[0,...,0]] \\\\
+\mathbf{W}\_O^{+} &= \mathbf{W}\_O \hspace{0.1cm} || \hspace{0.1cm} [[0,...,0],...,[0,...,0]] \\\\
+\end{aligned}
+\\]
+
+As a result, the vectors of generators \\(\mathbf{G},\mathbf{H}\\) and challenges \\(\mathbf{y}^n\\) are extended:
+
+\\[
+\begin{aligned}
+\mathbf{G}^{+}     &= \mathbf{G}   \hspace{0.1cm} || \hspace{0.1cm} [G_n,...,G_{n^{+}-1}] \\\\
+\mathbf{H}^{+}     &= \mathbf{H}   \hspace{0.1cm} || \hspace{0.1cm} [H_n,...,H_{n^{+}-1}] \\\\
+\mathbf{y}^{n^{+}} &= \mathbf{y}^n \hspace{0.1cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \\\\
+\end{aligned}
+\\]
+
+The low-level variables are padded with zeroes, so their commitments remain unchanged:
+
+\\[
+\begin{aligned}
+A_I^{+} &= \widetilde{B} \cdot \tilde{a} + \langle \mathbf{G}^{+} , \mathbf{a}\_L^{+} \rangle + \langle \mathbf{H}^{+}, \mathbf{a}\_R^{+} \rangle &{}={}& A_I \\\\
+A_O^{+} &= \widetilde{B} \cdot \tilde{o} + \langle \mathbf{G}^{+} , \mathbf{a}\_O^{+} \rangle                                                     &{}={}& A_O \\\\
+S^{+}   &= \widetilde{B} \cdot \tilde{s} + \langle \mathbf{G}^{+} , \mathbf{s}\_L^{+} \rangle + \langle \mathbf{H}^{+}, \mathbf{s}\_R^{+} \rangle &{}={}& S
+\end{aligned}
+\\]
+
+The flattened weight vectors \\(\mathbf{w}\_{L,R,O}\\) are padded with \\((n^{+} - n)\\) zeroes
+because the corresponding weights are padded with zeroes:
+\\[
+\begin{aligned}
+\mathbf{w}\_L^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_L^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_L) || (z \mathbf{z}^q \cdot [0,...,0]) &{}={}& \mathbf{w}\_L || [0,...,0], \\\\
+\mathbf{w}\_R^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_R^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_R) || (z \mathbf{z}^q \cdot [0,...,0]) &{}={}& \mathbf{w}\_R || [0,...,0], \\\\
+\mathbf{w}\_O^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_O^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_O) || (z \mathbf{z}^q \cdot [0,...,0]) &{}={}& \mathbf{w}\_O || [0,...,0]. \\\\
+\end{aligned}
+\\]
+
+The \\(\delta(y,z)\\) remains unchanged because the padding weights are zeroes:
+
+\\[
+\begin{aligned}
+\delta(y, z)^{+} &= \langle \mathbf{y}^{-n^{+}} \circ \mathbf{w}\_R^{+}, \mathbf{w}\_L^{+} \rangle \\\\
+                 &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_R, \mathbf{w}\_L \rangle      +     \langle [y^n,...,y^{n^{+}-1}] \circ [0,...,0], [0,...,0] \rangle \\\\
+                 &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_R, \mathbf{w}\_L \rangle      +     0 \\\\
+                 &= \delta(y, z)
+\end{aligned}
+\\]
+
+Finally, \\(\mathbf{l}(x)\\) is padded with zeroes and \\(\mathbf{r}(x)\\) is padded with additional powers of \\(y\\) in its 0th term:
+
+\\[
+\begin{aligned}
+\mathbf{l}(x)^{+} &= \mathbf{a}\_L^{+} \cdot x + \mathbf{s}\_L^{+} \cdot x^3 + \mathbf{y}^{-n^{+}} \circ \mathbf{w}\_R^{+} \cdot x + \mathbf{a}\_O^{+} \cdot x^2 \\\\
+                  &= \mathbf{a}\_L \cdot x + \mathbf{s}\_L \cdot x^3 + \mathbf{y}^{-n} \circ \mathbf{w}\_R \cdot x + \mathbf{a}\_O \cdot x^2 \\\\
+                  &  \hspace{0.5cm} || \hspace{0.1cm} [0,...,0] \cdot x + [0,...,0] \cdot x^3 + [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x + [0,...,0] \cdot x^2 \\\\
+                  &= \mathbf{l}(x) || [0,...,0] \\\\
+\mathbf{r}(x)^{+} &= \mathbf{y}^{n^{+}} \circ \mathbf{a}\_R^{+} \cdot x + \mathbf{y}^{n^{+}} \circ \mathbf{s}\_R^{+} \cdot x^3 + \mathbf{w}\_L^{+} \cdot x - \mathbf{y}^{n^{+}} + \mathbf{w}\_O^{+} \\\\
+				  &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O \\\\
+				  &  \hspace{0.5cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x + [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x^3 + [0,...,0] \cdot x - [y^n,...,y^{n^{+}-1}] + [0,...,0] \\\\
+				  &= \mathbf{r}(x) || [-y^n,...,-y^{n^{+}-1}]
+\end{aligned}
+\\]
 
 
 

--- a/docs/cs-proof.md
+++ b/docs/cs-proof.md
@@ -626,9 +626,7 @@ We will use the following notation for the padding:
 \\[
 \begin{aligned}
                            n^{+} &= 2^{\lceil \log_2 n \rceil} \\\\
-                      {\Delta n} &= n^{+} - n \\\\
-           \mathbf{0}^{\Delta n} &= [0,...,0] \\\\
-  \mathbf{0}^{q \times \Delta n} &= [[0,...,0], ..., [0,...,0]]
+                      \mathbf{0} &= [0,...,0]
 \end{aligned}
 \\]
 
@@ -640,14 +638,14 @@ for all constraints \\(i \in [0, q)\\) and all additional multipliers \\(j \in [
 
 \\[
 \begin{aligned}
-\mathbf{a}\_L^{+} &= \mathbf{a}\_L \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
-\mathbf{a}\_R^{+} &= \mathbf{a}\_R \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
-\mathbf{a}\_O^{+} &= \mathbf{a}\_O \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
-\mathbf{s}\_L^{+} &= \mathbf{s}\_L \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
-\mathbf{s}\_R^{+} &= \mathbf{s}\_R \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
-\mathbf{W}\_L^{+} &= \mathbf{W}\_L \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{q \times \Delta n} \\\\
-\mathbf{W}\_R^{+} &= \mathbf{W}\_R \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{q \times \Delta n} \\\\
-\mathbf{W}\_O^{+} &= \mathbf{W}\_O \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{q \times \Delta n} \\\\
+\mathbf{a}\_L^{+} &= \mathbf{a}\_L \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0} \\\\
+\mathbf{a}\_R^{+} &= \mathbf{a}\_R \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0} \\\\
+\mathbf{a}\_O^{+} &= \mathbf{a}\_O \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0} \\\\
+\mathbf{s}\_L^{+} &= \mathbf{s}\_L \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0} \\\\
+\mathbf{s}\_R^{+} &= \mathbf{s}\_R \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0} \\\\
+\mathbf{W}\_L^{+} &= \mathbf{W}\_L \hspace{0.1cm} || \hspace{0.1cm} [\mathbf{0}, ..., \mathbf{0}] \\\\
+\mathbf{W}\_R^{+} &= \mathbf{W}\_R \hspace{0.1cm} || \hspace{0.1cm} [\mathbf{0}, ..., \mathbf{0}] \\\\
+\mathbf{W}\_O^{+} &= \mathbf{W}\_O \hspace{0.1cm} || \hspace{0.1cm} [\mathbf{0}, ..., \mathbf{0}] \\\\
 \end{aligned}
 \\]
 
@@ -657,7 +655,7 @@ As a result, we have to take larger slices of the vectors of generators \\(\math
 \begin{aligned}
 \mathbf{G}^{+}     &= \mathbf{G}   \hspace{0.1cm} || \hspace{0.1cm} [G_n,...,G_{n^{+}-1}] \\\\
 \mathbf{H}^{+}     &= \mathbf{H}   \hspace{0.1cm} || \hspace{0.1cm} [H_n,...,H_{n^{+}-1}] \\\\
-\mathbf{y}^{n^{+}} &= \mathbf{y}^n \hspace{0.1cm} || \hspace{0.1cm} y^n \mathbf{y}^{\Delta n} \\\\
+\mathbf{y}^{n^{+}} &= \mathbf{y}^n \hspace{0.1cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \\\\
 \end{aligned}
 \\]
 
@@ -667,7 +665,7 @@ The low-level variables are padded with zeroes, so their commitments remain unch
 \begin{aligned}
 A_I^{+} &= \widetilde{B} \cdot \tilde{a} + \langle \mathbf{G}^{+}, \mathbf{a}\_L^{+} \rangle + \langle \mathbf{H}^{+}, \mathbf{a}\_R^{+} \rangle \\\\
         &= \widetilde{B} \cdot \tilde{a} + \langle \mathbf{G}, \mathbf{a}\_L \rangle + \langle \mathbf{H}, \mathbf{a}\_R \rangle +
-           \langle [G_n, ..., G_{n^{+}-1}], \mathbf{0}^{\Delta n} \rangle + \langle [H_n, ..., H_{n^{+}-1}], \mathbf{0}^{\Delta n} \rangle \\\\
+           \langle [G_n, ..., G_{n^{+}-1}], \mathbf{0} \rangle + \langle [H_n, ..., H_{n^{+}-1}], \mathbf{0} \rangle \\\\
 		&= \widetilde{B} \cdot \tilde{a} + \langle \mathbf{G}, \mathbf{a}\_L \rangle + \langle \mathbf{H}, \mathbf{a}\_R \rangle + 
 		   0 \\\\
         &= A_I \\\\
@@ -683,13 +681,13 @@ S^{+}   &= S
 \end{aligned}
 \\]
 
-The flattened weight vectors \\(\mathbf{w}\_{L,R,O}\\) are padded with \\(\Delta n\\) zeroes
+The flattened weight vectors \\(\mathbf{w}\_{L,R,O}\\) are padded with zeroes
 because the corresponding weights are padded with zeroes:
 \\[
 \begin{aligned}
-\mathbf{w}\_L^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_L^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_L) || (z \mathbf{z}^q \cdot \mathbf{0}^{\Delta n}) &{}={}& \mathbf{w}\_L || \mathbf{0}^{\Delta n}, \\\\
-\mathbf{w}\_R^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_R^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_R) || (z \mathbf{z}^q \cdot \mathbf{0}^{\Delta n}) &{}={}& \mathbf{w}\_R || \mathbf{0}^{\Delta n}, \\\\
-\mathbf{w}\_O^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_O^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_O) || (z \mathbf{z}^q \cdot \mathbf{0}^{\Delta n}) &{}={}& \mathbf{w}\_O || \mathbf{0}^{\Delta n}. \\\\
+\mathbf{w}\_L^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_L^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_L) || (z \mathbf{z}^q \cdot \mathbf{0}) &{}={}& \mathbf{w}\_L || \mathbf{0}, \\\\
+\mathbf{w}\_R^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_R^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_R) || (z \mathbf{z}^q \cdot \mathbf{0}) &{}={}& \mathbf{w}\_R || \mathbf{0}, \\\\
+\mathbf{w}\_O^{+} &= z \mathbf{z}^q \cdot \mathbf{W}\_O^{+}  &{}={}& (z \mathbf{z}^q \cdot \mathbf{W}\_O) || (z \mathbf{z}^q \cdot \mathbf{0}) &{}={}& \mathbf{w}\_O || \mathbf{0}. \\\\
 \end{aligned}
 \\]
 
@@ -698,7 +696,7 @@ The \\(\delta(y,z)\\) remains unchanged because the padding weights are zeroes:
 \\[
 \begin{aligned}
 \delta(y, z)^{+} &= \langle \mathbf{y}^{-n^{+}} \circ \mathbf{w}\_R^{+}, \mathbf{w}\_L^{+} \rangle \\\\
-                 &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_R, \mathbf{w}\_L \rangle      +     \langle [y^n,...,y^{n^{+}-1}] \circ \mathbf{0}^{\Delta n}, \mathbf{0}^{\Delta n} \rangle \\\\
+                 &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_R, \mathbf{w}\_L \rangle      +     \langle [y^n,...,y^{n^{+}-1}] \circ \mathbf{0}, \mathbf{0} \rangle \\\\
                  &= \langle \mathbf{y}^{-n} \circ \mathbf{w}\_R, \mathbf{w}\_L \rangle      +     0 \\\\
                  &= \delta(y, z)
 \end{aligned}
@@ -710,8 +708,8 @@ Vector polynomial \\(\mathbf{l}(x)\\) is padded with zeroes:
 \begin{aligned}
 \mathbf{l}(x)^{+} &= \mathbf{a}\_L^{+} \cdot x + \mathbf{s}\_L^{+} \cdot x^3 + \mathbf{y}^{-n^{+}} \circ \mathbf{w}\_R^{+} \cdot x + \mathbf{a}\_O^{+} \cdot x^2 \\\\
                   &= \mathbf{a}\_L \cdot x + \mathbf{s}\_L \cdot x^3 + \mathbf{y}^{-n} \circ \mathbf{w}\_R \cdot x + \mathbf{a}\_O \cdot x^2 \\\\
-                  &  \hspace{0.5cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \cdot x + \mathbf{0}^{\Delta n} \cdot x^3 + y^n \mathbf{y}^{\Delta n} \circ \mathbf{0}^{\Delta n} \cdot x + \mathbf{0}^{\Delta n} \cdot x^2 \\\\
-                  &= \mathbf{l}(x) || \mathbf{0}^{\Delta n} \\\\
+                  &  \hspace{0.5cm} || \hspace{0.1cm} \mathbf{0} \cdot x + \mathbf{0} \cdot x^3 + [y^n,...,y^{n^{+}-1}] \circ \mathbf{0} \cdot x + \mathbf{0} \cdot x^2 \\\\
+                  &= \mathbf{l}(x) || \mathbf{0} \\\\
 \end{aligned}
 \\]
 
@@ -721,8 +719,8 @@ Vector polynomial \\(\mathbf{r}(x)\\) is padded with additional powers of \\(y\\
 \begin{aligned}
 \mathbf{r}(x)^{+} &= \mathbf{y}^{n^{+}} \circ \mathbf{a}\_R^{+} \cdot x + \mathbf{y}^{n^{+}} \circ \mathbf{s}\_R^{+} \cdot x^3 + \mathbf{w}\_L^{+} \cdot x - \mathbf{y}^{n^{+}} + \mathbf{w}\_O^{+} \\\\
                   &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O \\\\
-                  &  \hspace{0.5cm} || \hspace{0.1cm} y^n \mathbf{y}^{\Delta n} \circ \mathbf{0}^{\Delta n} \cdot x + y^n \mathbf{y}^{\Delta n} \circ \mathbf{0}^{\Delta n} \cdot x^3 + \mathbf{0}^{\Delta n} \cdot x - y^n \mathbf{y}^{\Delta n} + \mathbf{0}^{\Delta n} \\\\
-                  &= \mathbf{r}(x) || y^n \mathbf{y}^{\Delta n}
+                  &  \hspace{0.5cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \circ \mathbf{0} \cdot x + [y^n,...,y^{n^{+}-1}] \circ \mathbf{0} \cdot x^3 + \mathbf{0} \cdot x - [y^n,...,y^{n^{+}-1}] + \mathbf{0} \\\\
+                  &= \mathbf{r}(x) || [y^n,...,y^{n^{+}-1}]
 \end{aligned}
 \\]
 
@@ -741,7 +739,7 @@ The inner product \\(t(x)\\) remains unchanged because the non-zero padding in t
 \\[
 \begin{aligned}
 t(x)^{+} &= {\langle {\mathbf{l}}(x)^{+}, {\mathbf{r}}(x)^{+} \rangle} \\\\
-         &= {\langle {\mathbf{l}}(x), {\mathbf{r}}(x) \rangle} + {\langle \mathbf{0}^{\Delta n}, y^n \mathbf{y}^{\Delta n} \rangle} \\\\
+         &= {\langle {\mathbf{l}}(x), {\mathbf{r}}(x) \rangle} + {\langle \mathbf{0}, [y^n,...,y^{n^{+}-1}] \rangle} \\\\
          &= {\langle {\mathbf{l}}(x), {\mathbf{r}}(x) \rangle} + 0 \\\\
          &= t(x)
 \end{aligned}
@@ -847,8 +845,8 @@ The prover evaluates polynomials \\(\mathbf{l}(x), \mathbf{r}(x)\\) and
 \\[
 \begin{aligned}
              n^{+} &= 2^{\lceil \log_2 n \rceil} \\\\
-\mathbf{l}^{+}     &= \mathbf{l}(x) \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0}^{\Delta n} \\\\
-\mathbf{r}^{+}     &= \mathbf{r}(x) \hspace{0.1cm} || \hspace{0.1cm} y^n \mathbf{y}^{\Delta n}
+\mathbf{l}^{+}     &= \mathbf{l}(x) \hspace{0.1cm} || \hspace{0.1cm} \mathbf{0} \\\\
+\mathbf{r}^{+}     &= \mathbf{r}(x) \hspace{0.1cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}]
 \end{aligned}
 \\]
 
@@ -857,7 +855,7 @@ The prover also takes a larger slice of the generators \\(\mathbf{G}, \mathbf{H}
 \\[
 \begin{aligned}
 \mathbf{G}^{+}     &= \mathbf{G}    \hspace{0.1cm} || \hspace{0.1cm} [G_n,...,G_{n^{+}-1}] \\\\
-{\mathbf{H}'}^{+}  &= \mathbf{H}'   \hspace{0.1cm} || \hspace{0.1cm} \Big( y^n \mathbf{y}^{\Delta n} \circ [H_n,...,H_{n^{+}-1}] \Big) \\\\
+{\mathbf{H}'}^{+}  &= \mathbf{H}'   \hspace{0.1cm} || \hspace{0.1cm} \Big( [y^n,...,y^{n^{+}-1}] \circ [H_n,...,H_{n^{+}-1}] \Big) \\\\
 \end{aligned}
 \\]
 
@@ -918,7 +916,6 @@ by taking a larger slice of the generators \\(\mathbf{G},\mathbf{H}\\) and more 
 \\[
 \begin{aligned}
              n^{+} &= 2^{\lceil \log_2 n \rceil} \\\\
-          \Delta n &= n^{+} - n \\\\
 \mathbf{G}^{+}     &= \mathbf{G}   \hspace{0.1cm} || \hspace{0.1cm} [G_n,...,G_{n^{+}-1}] \\\\
 \mathbf{H}^{+}     &= \mathbf{H}   \hspace{0.1cm} || \hspace{0.1cm} [H_n,...,H_{n^{+}-1}] \\\\
 \mathbf{y}^{n^{+}} &= \mathbf{y}^n \hspace{0.1cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \\\\
@@ -989,8 +986,8 @@ Finally, verifier groups all scalars by each point and performs a single multisc
                       + & \quad \sum\_{i = 1,3,4,5,6} r x^i T\_{i} \\\\
                       + & \quad \Big(w \big(t(x) - ab\big) + r \big(x^2 (w\_c + \delta(y,z)) - t(x)\big) \Big) \cdot B \\\\
                       + & \quad (-{\widetilde{e}} - r{\tilde{t}}(x)) \cdot \widetilde{B} \\\\
-                      + & \quad {\langle \big( x \mathbf{y}^{-n} \circ \mathbf{w}\_R \big) || \mathbf{0}^{\Delta n} - a\mathbf{s}, \mathbf{G}^{+} \rangle}\\\\
-                      + & \quad {\langle -\mathbf{1} + \mathbf{y}^{-n^{+}} \circ \big( (x \mathbf{w}\_L + \mathbf{w}\_O) || \mathbf{0}^{\Delta n} - (b /{\mathbf{s}}) \big), \mathbf{H}^{+} \rangle}\\\\
+                      + & \quad {\langle \big( x \mathbf{y}^{-n} \circ \mathbf{w}\_R \big) || \mathbf{0} - a\mathbf{s}, \mathbf{G}^{+} \rangle}\\\\
+                      + & \quad {\langle -\mathbf{1} + \mathbf{y}^{-n^{+}} \circ \big( (x \mathbf{w}\_L + \mathbf{w}\_O) || \mathbf{0} - (b /{\mathbf{s}}) \big), \mathbf{H}^{+} \rangle}\\\\
                       + & \quad {\langle [u_{1}^2,    \dots, u_{k}^2    ], [L_1, \dots, L_{k}] \rangle}\\\\
                       + & \quad {\langle [u_{1}^{-2}, \dots, u_{k}^{-2} ], [R_1, \dots, R_{k}] \rangle}
 \end{aligned}

--- a/docs/cs-proof.md
+++ b/docs/cs-proof.md
@@ -681,7 +681,7 @@ The \\(\delta(y,z)\\) remains unchanged because the padding weights are zeroes:
 \end{aligned}
 \\]
 
-Finally, \\(\mathbf{l}(x)\\) is padded with zeroes and \\(\mathbf{r}(x)\\) is padded with additional powers of \\(y\\) in its 0th term:
+Vector polynomials \\(\mathbf{l}(x)\\) is padded with zeroes and \\(\mathbf{r}(x)\\) is padded with additional powers of \\(y\\) in its 0th term:
 
 \\[
 \begin{aligned}
@@ -693,6 +693,15 @@ Finally, \\(\mathbf{l}(x)\\) is padded with zeroes and \\(\mathbf{r}(x)\\) is pa
                   &= \mathbf{y}^n \circ \mathbf{a}\_R \cdot x + \mathbf{y}^n \circ \mathbf{s}\_R \cdot x^3 + \mathbf{w}\_L \cdot x - \mathbf{y}^n + \mathbf{w}\_O \\\\
                   &  \hspace{0.5cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x + [y^n,...,y^{n^{+}-1}] \circ [0,...,0] \cdot x^3 + [0,...,0] \cdot x - [y^n,...,y^{n^{+}-1}] + [0,...,0] \\\\
                   &= \mathbf{r}(x) || [-y^n,...,-y^{n^{+}-1}]
+\end{aligned}
+\\]
+
+The commitments to these vector polynomials are also padded (\\(W\_{L,R,O}\\) remain unchanged because the weights are padded with zeroes):
+
+\\[
+\begin{aligned}
+  P^{+} &= -{\widetilde{e}} {\widetilde{B}} + x \cdot A_I + x^2 \cdot A_O - \langle \mathbf{1}, \mathbf{H}^{+} \rangle + W_L \cdot x + W_R \cdot x + W_O + x^3 \cdot S \\\\
+        &= P - \langle \mathbf{1}, [H_n,...,H_{n^{+}-1}] \rangle
 \end{aligned}
 \\]
 
@@ -708,6 +717,7 @@ t(x)^{+} &= {\langle {\mathbf{l}}(x)^{+}, {\mathbf{r}}(x)^{+} \rangle} \\\\
 \\]
 
 This implies that the terms \\(t\_{0, 1, 2, 3, 4, 5, 6}\\) also remain unchanged.
+
 
 Prover’s algorithm
 ------------------
@@ -864,10 +874,21 @@ The verifier flattens constraints:
 \\]
 where each of \\(\mathbf{w}\_L, \mathbf{w}\_R, \mathbf{w}\_O\\) has length \\(n\\) and \\(\mathbf{w}\_V\\) has length \\(m\\).
 
+The verifier [pads](#padding-mathbflx-and-mathbfrx-for-the-inner-product-proof) the generators \\(\mathbf{G},\mathbf{H}\\) and challenges \\(\mathbf{y}^n\\) to a power-of-two \\(n^{+}\\):
+
+\\[
+\begin{aligned}
+             n^{+} &= 2^{\lceil \log_2 n \rceil} \\\\
+\mathbf{G}^{+}     &= \mathbf{G}   \hspace{0.1cm} || \hspace{0.1cm} [G_n,...,G_{n^{+}-1}] \\\\
+\mathbf{H}^{+}     &= \mathbf{H}   \hspace{0.1cm} || \hspace{0.1cm} [H_n,...,H_{n^{+}-1}] \\\\
+\mathbf{y}^{n^{+}} &= \mathbf{y}^n \hspace{0.1cm} || \hspace{0.1cm} [y^n,...,y^{n^{+}-1}] \\\\
+\end{aligned}
+\\]
+
 The verifier computes the following scalars for the [inner product argument](../inner_product_proof/index.html):
 
 \\[
-	\\{u\_{1}^{2}, \dots, u\_{k}^{2}, u\_{1}^{-2}, \dots, u\_{k}^{-2}, s_0, \dots, s_{n-1}\\}
+	\\{u\_{1}^{2}, \dots, u\_{k}^{2}, u\_{1}^{-2}, \dots, u\_{k}^{-2}, s_0, \dots, s_{n^{+}-1}\\}
 \\]
 
 The goal of the verifier is to check two equations.
@@ -891,19 +912,19 @@ If we rewrite the check as a comparison with the identity point, we get:
 **Second**, verify the inner product argument for the vectors \\(\mathbf{l}(x), \mathbf{r}(x)\\) that form the \\(t(x)\\) (see [inner-product protocol](../inner_product_proof/index.html#verification-equation))
   
 \\[
-P' \overset ? = {\langle a \cdot {\mathbf{s}}, {\mathbf{G}} \rangle} + {\langle {\mathbf{y}^{-n}} \circ (b /{\mathbf{s}}), {\mathbf{H}} \rangle} + abQ - \sum\_{j=1}^{k} \left( L\_{j} u\_{j}^{2} + u\_{j}^{-2} R\_{j} \right).
+P' \overset ? = {\langle a \cdot \mathbf{s}, \mathbf{G}^{+} \rangle} + {\langle {\mathbf{y}^{-n^{+}}} \circ (b /{\mathbf{s}}), \mathbf{H}^{+} \rangle} + abQ - \sum\_{j=1}^{k} \left( L\_{j} u\_{j}^{2} + u\_{j}^{-2} R\_{j} \right).
 \\]
 
-Rewriting as a comparison with the identity point and expanding \\(Q = wB\\) and \\(P' = P + t(x) wB\\) as [needed for transition to the inner-product protocol](../notes/index.html#inner-product-proof):
+Rewriting as a comparison with the identity point and expanding \\(Q = wB\\) and \\(P' = P^{+} + t(x) wB\\) as [needed for transition to the inner-product protocol](../notes/index.html#inner-product-proof):
 
 \\[
-0 \overset ? = P + t(x) wB - {\langle a \cdot {\mathbf{s}}, {\mathbf{G}} \rangle} - {\langle {\mathbf{y}^{-n}} \circ (b /{\mathbf{s}}), {\mathbf{H}} \rangle} - abwB + \sum\_{j=1}^{k} \left( L\_{j} u\_{j}^{2} + u\_{j}^{-2} R\_{j} \right),
+0 \overset ? = P^{+} + t(x) wB - {\langle a \cdot \mathbf{s}, \mathbf{G}^{+} \rangle} - {\langle \mathbf{y}^{-n^{+}} \circ (b /\mathbf{s}), \mathbf{H}^{+} \rangle} - abwB + \sum\_{j=1}^{k} \left( L\_{j} u\_{j}^{2} + u\_{j}^{-2} R\_{j} \right),
 \\]
-where the [definition](#proving-that-mathbflx-mathbfrx-are-correct) of \\(P\\) is:
+where the [definition](#proving-that-mathbflx-mathbfrx-are-correct) of \\(P^{+}\\) is:
 
 \\[
 \begin{aligned}
-  P   = -{\widetilde{e}} {\widetilde{B}} + x \cdot A_I + x^2 \cdot A_O - \langle \mathbf{1}, \mathbf{H} \rangle + W_L \cdot x + W_R \cdot x + W_O + x^3 \cdot S
+  P^{+}   = -{\widetilde{e}} {\widetilde{B}} + x \cdot A_I + x^2 \cdot A_O - \langle \mathbf{1}, \mathbf{H}^{+} \rangle + W_L \cdot x + W_R \cdot x + W_O + x^3 \cdot S
 \end{aligned}
 \\]
 \\[
@@ -928,8 +949,8 @@ Finally, verifier groups all scalars by each point and performs a single multisc
                       + & \quad \sum\_{i = 1,3,4,5,6} r x^i T\_{i} \\\\
                       + & \quad \Big(w \big(t(x) - ab\big) + r \big(x^2 (w\_c + \delta(y,z)) - t(x)\big) \Big) \cdot B \\\\
                       + & \quad (-{\widetilde{e}} - r{\tilde{t}}(x)) \cdot \widetilde{B} \\\\
-                      + & \quad {\langle x \mathbf{y}^{-n} \circ \mathbf{w}\_R - a\mathbf{s}, \mathbf{G} \rangle}\\\\
-                      + & \quad {\langle -\mathbf{1} + \mathbf{y}^{-n} \circ \big( x \mathbf{w}\_L + \mathbf{w}\_O - (b /{\mathbf{s}}) \big), \mathbf{H} \rangle}\\\\
+                      + & \quad {\langle \big( x \mathbf{y}^{-n^{+}} \circ \mathbf{w}\_R \big) || [0,...,0] - a\mathbf{s}, \mathbf{G}^{+} \rangle}\\\\
+                      + & \quad {\langle -\mathbf{1} + \mathbf{y}^{-n^{+}} \circ \big( (x \mathbf{w}\_L + \mathbf{w}\_O) || [0,...,0] - (b /{\mathbf{s}}) \big), \mathbf{H}^{+} \rangle}\\\\
                       + & \quad {\langle [u_{1}^2,    \dots, u_{k}^2    ], [L_1, \dots, L_{k}] \rangle}\\\\
                       + & \quad {\langle [u_{1}^{-2}, \dots, u_{k}^{-2} ], [R_1, \dots, R_{k}] \rangle}
 \end{aligned}

--- a/src/circuit_proof/prover.rs
+++ b/src/circuit_proof/prover.rs
@@ -358,10 +358,16 @@ impl<'a, 'b> ProverCS<'a, 'b> {
 
         let t_x = t_poly.eval(x);
         let t_x_blinding = t_blinding_poly.eval(x);
-        let l_vec = l_poly.eval(x).into_iter()
-            .chain(iter::repeat(Scalar::zero()).take(pad)).collect::<Vec<_>>();
-        let mut r_vec = r_poly.eval(x).into_iter()
-            .chain(iter::repeat(Scalar::zero()).take(pad)).collect::<Vec<_>>();
+        let l_vec = l_poly
+            .eval(x)
+            .into_iter()
+            .chain(iter::repeat(Scalar::zero()).take(pad))
+            .collect::<Vec<_>>();
+        let mut r_vec = r_poly
+            .eval(x)
+            .into_iter()
+            .chain(iter::repeat(Scalar::zero()).take(pad))
+            .collect::<Vec<_>>();
 
         for i in n..padded_n {
             r_vec[i] = -exp_y;

--- a/src/circuit_proof/prover.rs
+++ b/src/circuit_proof/prover.rs
@@ -358,16 +358,11 @@ impl<'a, 'b> ProverCS<'a, 'b> {
 
         let t_x = t_poly.eval(x);
         let t_x_blinding = t_blinding_poly.eval(x);
-        let l_vec = l_poly
-            .eval(x)
-            .into_iter()
-            .chain(iter::repeat(Scalar::zero()).take(pad))
-            .collect::<Vec<_>>();
-        let mut r_vec = r_poly
-            .eval(x)
-            .into_iter()
-            .chain(iter::repeat(Scalar::zero()).take(pad))
-            .collect::<Vec<_>>();
+        let mut l_vec = l_poly.eval(x);
+        l_vec.append(&mut vec![Scalar::zero(); pad]);
+
+        let mut r_vec = r_poly.eval(x);
+        r_vec.append(&mut vec![Scalar::zero(); pad]);
 
         for i in n..padded_n {
             r_vec[i] = -exp_y;

--- a/src/circuit_proof/tests.rs
+++ b/src/circuit_proof/tests.rs
@@ -1,0 +1,469 @@
+use super::assignment::Assignment;
+use super::prover::ProverCS;
+use super::verifier::VerifierCS;
+use super::*;
+
+use errors::R1CSError;
+use generators::{BulletproofGens, PedersenGens};
+
+use curve25519_dalek::scalar::Scalar;
+use merlin::Transcript;
+
+use rand::thread_rng;
+
+/// Constrains (a1 + a2) * (b1 + b2) = (c1 + c2),
+/// where c2 is a constant.
+#[allow(non_snake_case)]
+fn example_gadget<CS: ConstraintSystem>(
+    cs: &mut CS,
+    a1: (Variable, Assignment),
+    a2: (Variable, Assignment),
+    b1: (Variable, Assignment),
+    b2: (Variable, Assignment),
+    c1: (Variable, Assignment),
+    c2: Scalar,
+) -> Result<(), R1CSError> {
+    // Make low-level variables (aL = v_a1 + v_a2, aR = v_b1 + v_b2, aO = v_c1 + v_c2)
+    let (aL, aR, aO) =
+        cs.assign_multiplier(a1.1 + a2.1, b1.1 + b2.1, c1.1 + Assignment::from(c2))?;
+
+    // Tie high-level and low-level variables together
+    let one = Scalar::one();
+    cs.add_constraint([(aL, -one), (a1.0, one), (a2.0, one)].iter().collect());
+    cs.add_constraint([(aR, -one), (b1.0, one), (b2.0, one)].iter().collect());
+    cs.add_constraint(
+        [(aO, -one), (c1.0, one), (Variable::One(), c2)]
+            .iter()
+            .collect(),
+    );
+
+    Ok(())
+}
+
+fn blinding_helper(len: usize) -> Vec<Scalar> {
+    (0..len)
+        .map(|_| Scalar::random(&mut thread_rng()))
+        .collect()
+}
+
+fn example_gadget_roundtrip_helper(
+    a1: u64,
+    a2: u64,
+    b1: u64,
+    b2: u64,
+    c1: u64,
+    c2: u64,
+) -> Result<(), R1CSError> {
+    // Common
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new(128, 1);
+
+    // Prover's scope
+    let (proof, commitments) = {
+        // 0. Construct transcript
+        let mut transcript = Transcript::new(b"R1CSExampleGadget");
+
+        // 1. Construct HL witness
+        let v: Vec<_> = [a1, a2, b1, b2, c1]
+            .iter()
+            .map(|x| Scalar::from(*x))
+            .collect();
+        let v_blinding = blinding_helper(v.len());
+
+        // 2. Construct CS
+        let (mut cs, vars, commitments) =
+            ProverCS::new(&bp_gens, &pc_gens, &mut transcript, v.clone(), v_blinding);
+
+        // 3. Add gadgets
+        example_gadget(
+            &mut cs,
+            (vars[0], v[0].into()),
+            (vars[1], v[1].into()),
+            (vars[2], v[2].into()),
+            (vars[3], v[3].into()),
+            (vars[4], v[4].into()),
+            c2.into(),
+        )?;
+
+        // 4. Prove.
+        let proof = cs.prove()?;
+
+        (proof, commitments)
+    };
+
+    // Verifier logic
+
+    // 0. Construct transcript
+    let mut transcript = Transcript::new(b"R1CSExampleGadget");
+
+    // 1. Construct CS using commitments to HL witness
+    let (mut cs, vars) = VerifierCS::new(&bp_gens, &pc_gens, &mut transcript, commitments);
+
+    // 2. Add gadgets
+    example_gadget(
+        &mut cs,
+        (vars[0], Assignment::Missing()),
+        (vars[1], Assignment::Missing()),
+        (vars[2], Assignment::Missing()),
+        (vars[3], Assignment::Missing()),
+        (vars[4], Assignment::Missing()),
+        c2.into(),
+    )?;
+
+    // 3. Verify.
+    cs.verify(&proof).map_err(|_| R1CSError::VerificationError)
+}
+
+#[test]
+fn example_gadget_test() {
+    // (3 + 4) * (6 + 1) = (40 + 9)
+    assert!(example_gadget_roundtrip_helper(3, 4, 6, 1, 40, 9).is_ok());
+    // (3 + 4) * (6 + 1) != (40 + 10)
+    assert!(example_gadget_roundtrip_helper(3, 4, 6, 1, 40, 10).is_err());
+}
+
+
+
+
+/// Shuffle gadget tests
+
+
+/* 
+K-SHUFFLE GADGET SPECIFICATION:
+
+Represents a permutation of a list of `k` scalars `{x_i}` into a list of `k` scalars `{y_i}`.
+
+Algebraically it can be expressed as a statement that for a free variable `z`, 
+the roots of the two polynomials in terms of `z` are the same up to a permutation:
+
+    ∏(x_i - z) == ∏(y_i - z)
+
+Prover can commit to blinded scalars `x_i` and `y_i` then receive a random challenge `z`, 
+and build a proof that the above relation holds.
+
+K-shuffle requires `2*(K-1)` multipliers.
+
+For K > 1:
+
+        (x_0 - z)---⊗------⊗---(y_0 - z)        // mulx[0], muly[0]
+                    |      |
+        (x_1 - z)---⊗      ⊗---(y_1 - z)        // mulx[1], muly[1]
+                    |      |
+                   ...    ...
+                    |      |
+    (x_{k-2} - z)---⊗      ⊗---(y_{k-2} - z)    // mulx[k-2], muly[k-2]
+                   /        \
+    (x_{k-1} - z)_/          \_(y_{k-1} - z)
+
+    // Connect left and right sides of the shuffle statement
+    mulx_out[0] = muly_out[0]
+
+    // For i == [0, k-3]:
+    mulx_left[i]  = x_i - z
+    mulx_right[i] = mulx_out[i+1]
+    muly_left[i]  = y_i - z
+    muly_right[i] = muly_out[i+1]
+
+    // last multipliers connect two last variables (on each side)
+    mulx_left[k-2]  = x_{k-2} - z
+    mulx_right[k-2] = x_{k-1} - z
+    muly_left[k-2]  = y_{k-2} - z
+    muly_right[k-2] = y_{k-1} - z
+
+For K = 1:
+
+    (x_0 - z)--------------(y_0 - z)
+
+    // Connect x to y directly, omitting the challenge entirely as it cancels out
+    x_0 = y_0
+*/
+
+// Make a gadget that adds constraints to a ConstraintSystem, such that the
+// y variables are constrained to be a valid shuffle of the x variables.
+struct KShuffleGadget {}
+
+/// Represents an error during the proof creation of verification for a KShuffle gadget.
+#[derive(Fail, Copy, Clone, Debug, Eq, PartialEq)]
+pub enum KShuffleError {
+    /// Error in the constraint system creation process
+    #[fail(display = "Invalid KShuffle constraint system construction")]
+    InvalidR1CSConstruction,
+    /// Occurs when there are insufficient generators for the proof.
+    #[fail(display = "Invalid generators size, too few generators for proof")]
+    InvalidGeneratorsLength,
+    /// Occurs when verification of an [`R1CSProof`](::r1cs::R1CSProof) fails.
+    #[fail(display = "R1CSProof did not verify correctly.")]
+    VerificationError,
+}
+
+impl From<R1CSError> for KShuffleError {
+    fn from(e: R1CSError) -> KShuffleError {
+        match e {
+            R1CSError::InvalidGeneratorsLength => KShuffleError::InvalidGeneratorsLength,
+            R1CSError::MissingAssignment => KShuffleError::InvalidR1CSConstruction,
+            R1CSError::VerificationError => KShuffleError::VerificationError,
+        }
+    }
+}
+
+impl KShuffleGadget {
+    fn fill_cs<CS: ConstraintSystem>(
+        cs: &mut CS,
+        x: Vec<(Variable, Assignment)>,
+        y: Vec<(Variable, Assignment)>,
+    ) -> Result<(), KShuffleError> {
+        let one = Scalar::one();
+        let z = cs.challenge_scalar(b"k-shuffle challenge");
+        let neg_z = -z;
+        if x.len() != y.len() {
+            return Err(KShuffleError::InvalidR1CSConstruction);
+        }
+        let k = x.len();
+        if k == 1 {
+            cs.add_constraint([(x[0].0, -one), (y[0].0, one)].iter().collect());
+            return Ok(());
+        }
+        // Make last x multiplier for i = k-1 and k-2
+        let mut mulx_left = x[k - 1].1 + neg_z;
+        let mut mulx_right = x[k - 2].1 + neg_z;
+        let mut mulx_out = mulx_left * mulx_right;
+        let mut mulx_out_var_prev = KShuffleGadget::multiplier_helper(
+            cs,
+            neg_z,
+            mulx_left,
+            mulx_right,
+            mulx_out,
+            x[k - 1].0,
+            x[k - 2].0,
+            true,
+        )?;
+        // Make multipliers for x from i == [0, k-3]
+        for i in (0..k - 2).rev() {
+            mulx_left = mulx_out;
+            mulx_right = x[i].1 + neg_z;
+            mulx_out = mulx_left * mulx_right;
+            mulx_out_var_prev = KShuffleGadget::multiplier_helper(
+                cs,
+                neg_z,
+                mulx_left,
+                mulx_right,
+                mulx_out,
+                mulx_out_var_prev,
+                x[i].0,
+                false,
+            )?;
+        }
+        // Make last y multiplier for i = k-1 and k-2
+        let mut muly_left = y[k - 1].1 - z;
+        let mut muly_right = y[k - 2].1 - z;
+        let mut muly_out = muly_left * muly_right;
+        let mut muly_out_var_prev = KShuffleGadget::multiplier_helper(
+            cs,
+            neg_z,
+            muly_left,
+            muly_right,
+            muly_out,
+            y[k - 1].0,
+            y[k - 2].0,
+            true,
+        )?;
+        // Make multipliers for y from i == [0, k-3]
+        for i in (0..k - 2).rev() {
+            muly_left = muly_out;
+            muly_right = y[i].1 + neg_z;
+            muly_out = muly_left * muly_right;
+            muly_out_var_prev = KShuffleGadget::multiplier_helper(
+                cs,
+                neg_z,
+                muly_left,
+                muly_right,
+                muly_out,
+                muly_out_var_prev,
+                y[i].0,
+                false,
+            )?;
+        }
+        // Check equality between last x mul output and last y mul output
+        cs.add_constraint(
+            [(muly_out_var_prev, -one), (mulx_out_var_prev, one)]
+                .iter()
+                .collect(),
+        );
+        Ok(())
+    }
+
+    fn multiplier_helper<CS: ConstraintSystem>(
+        cs: &mut CS,
+        neg_z: Scalar,
+        left: Assignment,
+        right: Assignment,
+        out: Assignment,
+        left_var: Variable,
+        right_var: Variable,
+        is_last_mul: bool,
+    ) -> Result<Variable, KShuffleError> {
+        let one = Scalar::one();
+        let var_one = Variable::One();
+        // Make multiplier gate variables
+        let (left_mul_var, right_mul_var, out_mul_var) = cs.assign_multiplier(left, right, out)?;
+        if is_last_mul {
+            // Make last multiplier
+            cs.add_constraint(
+                [(left_mul_var, -one), (var_one, neg_z), (left_var, one)]
+                    .iter()
+                    .collect(),
+            );
+        } else {
+            // Make intermediate multiplier
+            cs.add_constraint([(left_mul_var, -one), (left_var, one)].iter().collect());
+        }
+        cs.add_constraint(
+            [(right_mul_var, -one), (var_one, neg_z), (right_var, one)]
+                .iter()
+                .collect(),
+        );
+        Ok(out_mul_var)
+    }
+}
+
+
+// Helper functions for proof creation
+fn kshuffle_prover_cs<'a, 'b>(
+    pc_gens: &'b PedersenGens,
+    bp_gens: &'b BulletproofGens,
+    transcript: &'a mut Transcript,
+    input: &Vec<u64>,
+    output: &Vec<u64>,
+) -> Result<(ProverCS<'a, 'b>, Vec<CompressedRistretto>), KShuffleError> {
+    let k = input.len();
+
+    // Prover makes a `ConstraintSystem` instance representing a shuffle gadget
+    // Make v vector
+    let mut v = Vec::with_capacity(2 * k);
+    for i in 0..k {
+        v.push(Scalar::from(input[i]));
+    }
+    for i in 0..k {
+        v.push(Scalar::from(output[i]));
+    }
+
+    // Make v_blinding vector using RNG from transcript
+    let mut rng = {
+        let mut builder = transcript.build_rng();
+        // commit the secret values
+        for &v_i in &v {
+            builder = builder.commit_witness_bytes(b"v_i", v_i.as_bytes());
+        }
+        use rand::thread_rng;
+        builder.finalize(&mut thread_rng())
+    };
+    let v_blinding: Vec<Scalar> = (0..2 * k).map(|_| Scalar::random(&mut rng)).collect();
+    let (mut prover_cs, variables, commitments) =
+        ProverCS::new(&bp_gens, &pc_gens, transcript, v, v_blinding.clone());
+
+    // Prover allocates variables and adds constraints to the constraint system
+    let in_pairs = variables[0..k]
+        .iter()
+        .zip(input.iter())
+        .map(|(var_i, in_i)| (*var_i, Assignment::from(in_i.clone())))
+        .collect();
+    let out_pairs = variables[k..2 * k]
+        .iter()
+        .zip(output.iter())
+        .map(|(var_i, out_i)| (*var_i, Assignment::from(out_i.clone())))
+        .collect();
+    KShuffleGadget::fill_cs(&mut prover_cs, in_pairs, out_pairs).unwrap();
+
+    Ok((prover_cs, commitments))
+}
+
+// Helper functions for proof verification
+fn kshuffle_verifier_cs<'a, 'b>(
+    pc_gens: &'b PedersenGens,
+    bp_gens: &'b BulletproofGens,
+    transcript: &'a mut Transcript,
+    commitments: &Vec<CompressedRistretto>,
+) -> Result<VerifierCS<'a, 'b>, KShuffleError> {
+    let k = commitments.len() / 2;
+
+    // Verifier makes a `ConstraintSystem` instance representing a shuffle gadget
+    let (mut verifier_cs, variables) =
+        VerifierCS::new(&bp_gens, &pc_gens, transcript, commitments.to_vec());
+
+    // Verifier allocates variables and adds constraints to the constraint system
+    let in_pairs = variables[0..k]
+        .iter()
+        .map(|var_i| (*var_i, Assignment::Missing()))
+        .collect();
+    let out_pairs = variables[k..2 * k]
+        .iter()
+        .map(|var_i| (*var_i, Assignment::Missing()))
+        .collect();
+    KShuffleGadget::fill_cs(&mut verifier_cs, in_pairs, out_pairs)?;
+
+    Ok(verifier_cs)
+}
+
+
+fn shuffle_gadget_test_helper(k: usize) {
+    use rand::Rng;
+    use merlin::Transcript;
+
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new((2*k).next_power_of_two(), 1);
+
+    let mut transcript = Transcript::new(b"ShuffleTest");
+    transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
+
+    let (proof, commitments) = {
+        // Generate inputs and outputs to kshuffle
+        let mut rng = rand::thread_rng();
+        let (min, max) = (0u64, std::u64::MAX);
+        let input: Vec<u64> = (0..k).map(|_| rng.gen_range(min, max)).collect();
+        let mut output = input.clone();
+        rand::thread_rng().shuffle(&mut output);
+        
+        let mut prover_transcript = transcript.clone();
+        let (prover_cs, commits) =
+            kshuffle_prover_cs(&pc_gens, &bp_gens, &mut prover_transcript, &input, &output)
+                .unwrap();
+        let proof = prover_cs.prove().unwrap();
+        (proof, commits)
+    };
+
+    {
+        let mut verifier_transcript = transcript.clone();
+
+        let verifier_cs =
+            kshuffle_verifier_cs(&pc_gens, &bp_gens, &mut verifier_transcript, &commitments)
+                .unwrap();
+        verifier_cs.verify(&proof).unwrap();
+    }
+}
+
+#[test]
+fn shuffle_gadget_test_1() { shuffle_gadget_test_helper(1); }
+
+#[test]
+fn shuffle_gadget_test_2() { shuffle_gadget_test_helper(2); }
+
+#[test]
+fn shuffle_gadget_test_3() { shuffle_gadget_test_helper(3); }
+
+#[test]
+fn shuffle_gadget_test_4() { shuffle_gadget_test_helper(4); }
+
+#[test]
+fn shuffle_gadget_test_5() { shuffle_gadget_test_helper(5); }
+
+#[test]
+fn shuffle_gadget_test_6() { shuffle_gadget_test_helper(6); }
+
+#[test]
+fn shuffle_gadget_test_7() { shuffle_gadget_test_helper(7); }
+
+#[test]
+fn shuffle_gadget_test_24() { shuffle_gadget_test_helper(24); }
+
+#[test]
+fn shuffle_gadget_test_42() { shuffle_gadget_test_helper(42); }

--- a/src/circuit_proof/tests.rs
+++ b/src/circuit_proof/tests.rs
@@ -122,11 +122,7 @@ fn example_gadget_test() {
     assert!(example_gadget_roundtrip_helper(3, 4, 6, 1, 40, 10).is_err());
 }
 
-
-
-
 /// Shuffle gadget tests
-
 
 /* 
 K-SHUFFLE GADGET SPECIFICATION:
@@ -326,7 +322,6 @@ impl KShuffleGadget {
     }
 }
 
-
 // Helper functions for proof creation
 fn kshuffle_prover_cs<'a, 'b>(
     pc_gens: &'b PedersenGens,
@@ -404,13 +399,12 @@ fn kshuffle_verifier_cs<'a, 'b>(
     Ok(verifier_cs)
 }
 
-
 fn shuffle_gadget_test_helper(k: usize) {
-    use rand::Rng;
     use merlin::Transcript;
+    use rand::Rng;
 
     let pc_gens = PedersenGens::default();
-    let bp_gens = BulletproofGens::new((2*k).next_power_of_two(), 1);
+    let bp_gens = BulletproofGens::new((2 * k).next_power_of_two(), 1);
 
     let mut transcript = Transcript::new(b"ShuffleTest");
     transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
@@ -422,7 +416,7 @@ fn shuffle_gadget_test_helper(k: usize) {
         let input: Vec<u64> = (0..k).map(|_| rng.gen_range(min, max)).collect();
         let mut output = input.clone();
         rand::thread_rng().shuffle(&mut output);
-        
+
         let mut prover_transcript = transcript.clone();
         let (prover_cs, commits) =
             kshuffle_prover_cs(&pc_gens, &bp_gens, &mut prover_transcript, &input, &output)
@@ -442,28 +436,46 @@ fn shuffle_gadget_test_helper(k: usize) {
 }
 
 #[test]
-fn shuffle_gadget_test_1() { shuffle_gadget_test_helper(1); }
+fn shuffle_gadget_test_1() {
+    shuffle_gadget_test_helper(1);
+}
 
 #[test]
-fn shuffle_gadget_test_2() { shuffle_gadget_test_helper(2); }
+fn shuffle_gadget_test_2() {
+    shuffle_gadget_test_helper(2);
+}
 
 #[test]
-fn shuffle_gadget_test_3() { shuffle_gadget_test_helper(3); }
+fn shuffle_gadget_test_3() {
+    shuffle_gadget_test_helper(3);
+}
 
 #[test]
-fn shuffle_gadget_test_4() { shuffle_gadget_test_helper(4); }
+fn shuffle_gadget_test_4() {
+    shuffle_gadget_test_helper(4);
+}
 
 #[test]
-fn shuffle_gadget_test_5() { shuffle_gadget_test_helper(5); }
+fn shuffle_gadget_test_5() {
+    shuffle_gadget_test_helper(5);
+}
 
 #[test]
-fn shuffle_gadget_test_6() { shuffle_gadget_test_helper(6); }
+fn shuffle_gadget_test_6() {
+    shuffle_gadget_test_helper(6);
+}
 
 #[test]
-fn shuffle_gadget_test_7() { shuffle_gadget_test_helper(7); }
+fn shuffle_gadget_test_7() {
+    shuffle_gadget_test_helper(7);
+}
 
 #[test]
-fn shuffle_gadget_test_24() { shuffle_gadget_test_helper(24); }
+fn shuffle_gadget_test_24() {
+    shuffle_gadget_test_helper(24);
+}
 
 #[test]
-fn shuffle_gadget_test_42() { shuffle_gadget_test_helper(42); }
+fn shuffle_gadget_test_42() {
+    shuffle_gadget_test_helper(42);
+}

--- a/src/circuit_proof/verifier.rs
+++ b/src/circuit_proof/verifier.rs
@@ -189,24 +189,17 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
 
     /// Consume this `VerifierCS` and attempt to verify the supplied `proof`.
     pub fn verify(mut self, proof: &R1CSProof) -> Result<(), R1CSError> {
-        let temp_n = self.num_vars;
-        if !(temp_n == 0 || temp_n.is_power_of_two()) {
-            let pad = temp_n.next_power_of_two() - temp_n;
-            for _ in 0..pad {
-                let _ = self.assign_multiplier(
-                    Scalar::zero().into(),
-                    Scalar::zero().into(),
-                    Scalar::zero().into(),
-                );
-            }
-        }
+
+        // If the number of multiplications is not 0 or a power of 2, then pad the circuit.
+        let n = self.num_vars;
+        let padded_n = self.num_vars.next_power_of_two();
+        let pad = padded_n - n;
 
         use inner_product_proof::inner_product;
         use std::iter;
         use util;
 
-        let n = self.num_vars;
-        if self.bp_gens.gens_capacity < n {
+        if self.bp_gens.gens_capacity < padded_n {
             return Err(R1CSError::InvalidGeneratorsLength);
         }
         // We are performing a single-party circuit proof, so party index is 0.
@@ -244,26 +237,27 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
         let b = proof.ipp_proof.b;
 
         let y_inv = y.invert();
-        let y_inv_vec = util::exp_iter(y_inv).take(n).collect::<Vec<Scalar>>();
+        let y_inv_vec = util::exp_iter(y_inv).take(padded_n).collect::<Vec<Scalar>>();
         let yneg_wR = wR
-            .iter()
+            .into_iter()
             .zip(y_inv_vec.iter())
             .map(|(wRi, exp_y_inv)| wRi * exp_y_inv)
+            .chain(iter::repeat(Scalar::zero()).take(pad))
             .collect::<Vec<Scalar>>();
 
-        let delta = inner_product(&yneg_wR, &wL);
+        let delta = inner_product(&yneg_wR[0..n], &wL);
 
         // define parameters for P check
         let g_scalars = yneg_wR
             .iter()
-            .zip(s.iter().take(n))
+            .zip(s.iter().take(padded_n))
             .map(|(yneg_wRi, s_i)| x * yneg_wRi - a * s_i);
 
         let h_scalars = y_inv_vec
             .iter()
-            .zip(s.iter().rev().take(n))
-            .zip(wL.iter())
-            .zip(wO.iter())
+            .zip(s.iter().rev().take(padded_n))
+            .zip(wL.into_iter().chain(iter::repeat(Scalar::zero()).take(pad)))
+            .zip(wO.into_iter().chain(iter::repeat(Scalar::zero()).take(pad)))
             .map(|(((y_inv_i, s_i_inv), wLi), wOi)| {
                 y_inv_i * (x * wLi + wOi - b * s_i_inv) - Scalar::one()
             });
@@ -302,8 +296,8 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
                 .chain(T_points.iter().map(|T_i| T_i.decompress()))
                 .chain(iter::once(Some(self.pc_gens.B)))
                 .chain(iter::once(Some(self.pc_gens.B_blinding)))
-                .chain(gens.G(n).map(|&G_i| Some(G_i)))
-                .chain(gens.H(n).map(|&H_i| Some(H_i)))
+                .chain(gens.G(padded_n).map(|&G_i| Some(G_i)))
+                .chain(gens.H(padded_n).map(|&H_i| Some(H_i)))
                 .chain(proof.ipp_proof.L_vec.iter().map(|L_i| L_i.decompress()))
                 .chain(proof.ipp_proof.R_vec.iter().map(|R_i| R_i.decompress())),
         )

--- a/src/circuit_proof/verifier.rs
+++ b/src/circuit_proof/verifier.rs
@@ -189,7 +189,6 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
 
     /// Consume this `VerifierCS` and attempt to verify the supplied `proof`.
     pub fn verify(mut self, proof: &R1CSProof) -> Result<(), R1CSError> {
-
         // If the number of multiplications is not 0 or a power of 2, then pad the circuit.
         let n = self.num_vars;
         let padded_n = self.num_vars.next_power_of_two();
@@ -237,7 +236,9 @@ impl<'a, 'b> VerifierCS<'a, 'b> {
         let b = proof.ipp_proof.b;
 
         let y_inv = y.invert();
-        let y_inv_vec = util::exp_iter(y_inv).take(padded_n).collect::<Vec<Scalar>>();
+        let y_inv_vec = util::exp_iter(y_inv)
+            .take(padded_n)
+            .collect::<Vec<Scalar>>();
         let yneg_wR = wR
             .into_iter()
             .zip(y_inv_vec.iter())


### PR DESCRIPTION
This adds notes and implementation of a lower-level padding of the proof components as required by the inner product argument.

Closes #156

<img width="903" alt="image" src="https://user-images.githubusercontent.com/698/46896787-eecf0a00-ce33-11e8-9281-c8712e7d1206.png">