### PR TITLE
Revert unsound attempt to clear secrets on the stack 

### DIFF
--- a/src/circuit_proof/assignment.rs
+++ b/src/circuit_proof/assignment.rs
@@ -18,7 +18,7 @@ pub enum Assignment {
     Missing(),
 }
 
-// Default implementation is used for zeroing secrets from allocated memory via `clear_on_drop`.
+// Default implementation is used for zeroizing secrets from allocated memory via `clear_on_drop`.
 impl Default for Assignment {
     fn default() -> Assignment {
         Assignment::Missing()

--- a/src/circuit_proof/assignment.rs
+++ b/src/circuit_proof/assignment.rs
@@ -18,7 +18,7 @@ pub enum Assignment {
     Missing(),
 }
 
-// Default implementation is used for zeroizing secrets from allocated memory via `clear_on_drop`.
+// Default implementation is used for zeroing secrets from allocated memory via `clear_on_drop`.
 impl Default for Assignment {
     fn default() -> Assignment {
         Assignment::Missing()

--- a/src/circuit_proof/prover.rs
+++ b/src/circuit_proof/prover.rs
@@ -270,9 +270,9 @@ impl<'a, 'b> ProverCS<'a, 'b> {
 
         // 3. Choose blinding factors and form commitments to low-level witness data
 
-        let mut i_blinding = Scalar::random(&mut rng);
-        let mut o_blinding = Scalar::random(&mut rng);
-        let mut s_blinding = Scalar::random(&mut rng);
+        let i_blinding = Scalar::random(&mut rng);
+        let o_blinding = Scalar::random(&mut rng);
+        let s_blinding = Scalar::random(&mut rng);
 
         let mut s_L: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
         let mut s_R: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
@@ -413,10 +413,6 @@ impl<'a, 'b> ProverCS<'a, 'b> {
             l_vec,
             r_vec,
         );
-
-        i_blinding.clear();
-        o_blinding.clear();
-        s_blinding.clear();
 
         // We do not yet have a ClearOnDrop wrapper for Vec<Scalar>.
         // When PR 202 [1] is merged, we can simply wrap s_L and s_R at the point of creation.

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -81,7 +81,7 @@ impl<'a> PartyAwaitingPosition<'a> {
 
         let bp_share = self.bp_gens.share(j);
 
-        let mut a_blinding = Scalar::random(&mut rng);
+        let a_blinding = Scalar::random(&mut rng);
         // Compute A = <a_L, G> + <a_R, H> + a_blinding * B_blinding
         let mut A = self.pc_gens.B_blinding * a_blinding;
 
@@ -97,7 +97,7 @@ impl<'a> PartyAwaitingPosition<'a> {
             i += 1;
         }
 
-        let mut s_blinding = Scalar::random(&mut rng);
+        let s_blinding = Scalar::random(&mut rng);
         let s_L: Vec<Scalar> = (0..self.n).map(|_| Scalar::random(&mut rng)).collect();
         let s_R: Vec<Scalar> = (0..self.n).map(|_| Scalar::random(&mut rng)).collect();
 
@@ -126,10 +126,6 @@ impl<'a> PartyAwaitingPosition<'a> {
             s_L,
             s_R,
         };
-
-        a_blinding.clear();
-        s_blinding.clear();
-
         Ok((next_state, bit_commitment))
     }
 }
@@ -192,8 +188,8 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
         let t_poly = l_poly.inner_product(&r_poly);
 
         // Generate x by committing to T_1, T_2 (line 49-54)
-        let mut t_1_blinding = Scalar::random(&mut rng);
-        let mut t_2_blinding = Scalar::random(&mut rng);
+        let t_1_blinding = Scalar::random(&mut rng);
+        let t_2_blinding = Scalar::random(&mut rng);
         let T_1 = self.pc_gens.commit(t_poly.1, t_1_blinding);
         let T_2 = self.pc_gens.commit(t_poly.2, t_2_blinding);
 
@@ -214,9 +210,6 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
             t_1_blinding,
             t_2_blinding,
         };
-
-        t_1_blinding.clear();
-        t_2_blinding.clear();
 
         (papc, poly_commitment)
     }


### PR DESCRIPTION
Discussed here: 
https://github.com/dalek-cryptography/bulletproofs/pull/193#discussion_r226409056

>Manually clearing a few particular stack variables isn't really effective, because what you need to clear is both the secrets as well as all secret-derived data. For heap allocations, the idea is that the secret-derived data is probably going to live on the stack, so the only zeroing targets on the heap are the variables themselves. But if you want to try to clear stack data, you really need to wipe the entire stack. This is difficult because as the programmer, you don't actually control the stack allocation.
>
>More specifically, the commit that adds the clearing for stack variables makes mutable a bunch of data that should be immutable, but also doesn't actually erase all the stack data, so it doesn't seem like an improvement.