### PR TITLE
Explicitly cap allocations inside IPP verification

### DIFF
--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -184,7 +184,7 @@ impl InnerProductProof {
         transcript: &mut Transcript,
     ) -> Result<(Vec<Scalar>, Vec<Scalar>, Vec<Scalar>), ProofError> {
         let lg_n = self.L_vec.len();
-        if lg_n > 32 {
+        if lg_n >= 32 {
             // 4 billion multiplications should be enough for anyone
             // and this check prevents overflow in 1<<lg_n below.
             return Err(ProofError::VerificationError);

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -312,7 +312,7 @@ impl RangeProof {
         // Challenge value for batching statements to be verified
         let c = Scalar::random(&mut rng);
 
-        let (x_sq, x_inv_sq, s) = self.ipp_proof.verification_scalars(transcript);
+        let (x_sq, x_inv_sq, s) = self.ipp_proof.verification_scalars(n * m, transcript)?;
         let s_inv = s.iter().rev();
 
         let a = self.ipp_proof.a;
@@ -555,13 +555,6 @@ mod tests {
             // 2. Return serialized proof and value commitments
             (bincode::serialize(&proof).unwrap(), value_commitments)
         };
-
-        println!(
-            "Aggregated rangeproof of m={} proofs of n={} bits has size {} bytes",
-            m,
-            n,
-            proof_bytes.len(),
-        );
 
         // Verifier's scope
         {


### PR DESCRIPTION
This patch eliminates blind allocation of `O(2^k)` array inside the inner product verification function based on the untrusted input of `O(k)` length.

For the rangeproof the cap is enforced in the rangeproof layer that caps the `2^k` to `64*<parties>` and for the constraint system it could be explicitly written as a metadata on a proof. 