### PR TITLE
Simplify t1 calculation for polynomial

### DIFF
--- a/docs/notes.md
+++ b/docs/notes.md
@@ -316,7 +316,7 @@ we can express the coefficients of \\(t(x)\\) using Karatsuba’s method:
 \begin{aligned}
   t\_{0} &= {\langle {\mathbf{l}}\_{0}, {\mathbf{r}}\_{0} \rangle},  \\\\
   t\_{2} &= {\langle {\mathbf{l}}\_{1}, {\mathbf{r}}\_{1} \rangle},  \\\\
-  t\_{1} &= {\langle {\mathbf{l}}\_{0} + {\mathbf{l}}\_{1}, {\mathbf{r}}\_{0} + {\mathbf{r}}\_{1} \rangle} - t\_{0} - t\_{2} 
+  t\_{1} &= {\langle {\mathbf{l}}\_{0} + {\mathbf{l}}\_{1}, {\mathbf{r}}\_{0} + {\mathbf{r}}\_{1} \rangle} - t\_{0} - t\_{2} &= {\langle {\mathbf{l}}\_{1}, {\mathbf{r}}\_{0} \rangle} + {\langle {\mathbf{l}}\_{0}, {\mathbf{r}}\_{1} \rangle}
 \end{aligned}
 \\]
 Since \\[

--- a/src/util.rs
+++ b/src/util.rs
@@ -39,18 +39,6 @@ pub fn exp_iter(x: Scalar) -> ScalarExp {
     ScalarExp { x, next_exp_x }
 }
 
-pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
-    let mut out = Vec::new();
-    if a.len() != b.len() {
-        // throw some error
-        println!("lengths of vectors don't match for vector addition");
-    }
-    for i in 0..a.len() {
-        out.push(a[i] + b[i]);
-    }
-    out
-}
-
 impl VecPoly1 {
     pub fn zero(n: usize) -> Self {
         VecPoly1(vec![Scalar::zero(); n], vec![Scalar::zero(); n])
@@ -64,10 +52,7 @@ impl VecPoly1 {
         let t0 = inner_product(&l.0, &r.0);
         let t2 = inner_product(&l.1, &r.1);
 
-        let l0_plus_l1 = add_vec(&l.0, &l.1);
-        let r0_plus_r1 = add_vec(&r.0, &r.1);
-
-        let t1 = inner_product(&l0_plus_l1, &r0_plus_r1) - t0 - t2;
+        let t1 = inner_product(&l.1, &r.0) + inner_product(&l.0, &r.1);
 
         Poly2(t0, t1, t2)
     }


### PR DESCRIPTION
Because the inner product has linearity in the first and second component:

    <a+b,c> = <a,c> + <b,c>
and 
    <c, a+b> = <c,a> + <c,b>

We can rewrite <l_0+l_1, r_0 + r_1> as:

    <l_0, r_0+r_1> + <l_1, r_0+r_1> = <l_0, r_0> + <l_0,r_1> + <l_1, r_0> + <l_1,r_1>

t_1 can be rewritten as <l_0, r_0> + <l_0,r_1> + <l_1, r_0> + <l_1,r_1> - <l_0, r_0> - <l_1,r_1> = <l_0,r_1> + <l_1, r_0>