### PR TITLE
Allow committing high-level variables one-by-one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ criterion = "0.2"
 bincode = "1"
 
 [features]
+default = ["yoloproofs"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
 

--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -1,5 +1,5 @@
 extern crate bulletproofs;
-use bulletproofs::r1cs::{ConstraintSystem, ProverCS, R1CSError, R1CSProof, Variable, VerifierCS};
+use bulletproofs::r1cs::{ConstraintSystem, Prover, R1CSError, R1CSProof, Variable, Verifier};
 use bulletproofs::{BulletproofGens, PedersenGens};
 
 #[macro_use]
@@ -115,36 +115,41 @@ impl KShuffleGadget {
         transcript: &'a mut Transcript,
         input: &[Scalar],
         output: &[Scalar],
-    ) -> Result<(R1CSProof, Vec<CompressedRistretto>), R1CSError> {
+    ) -> Result<
+        (
+            R1CSProof,
+            Vec<CompressedRistretto>,
+            Vec<CompressedRistretto>,
+        ),
+        R1CSError,
+    > {
+        // Apply a domain separator with the shuffle parameters to the transcript
         let k = input.len();
+        transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
+        transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        // Prover makes a `ConstraintSystem` instance representing a shuffle gadget
-        // Make v vector
-        let mut v = Vec::with_capacity(2 * k);
-        v.extend_from_slice(input);
-        v.extend_from_slice(output);
+        let mut prover = Prover::new(&bp_gens, &pc_gens, transcript);
 
-        // Make v_blinding vector using RNG from transcript
-        let mut rng = {
-            let mut builder = transcript.build_rng();
-            // commit the secret values
-            for &v_i in &v {
-                builder = builder.commit_witness_bytes(b"v_i", v_i.as_bytes());
-            }
-            use rand::thread_rng;
-            builder.finalize(&mut thread_rng())
-        };
-        let v_blinding: Vec<Scalar> = (0..2 * k).map(|_| Scalar::random(&mut rng)).collect();
-        let (mut prover_cs, variables, commitments) =
-            ProverCS::new(&bp_gens, &pc_gens, transcript, v, v_blinding.clone());
+        // Construct blinding factors using an RNG.
+        // Note: a non-example implementation would want to operate on existing commitments.
+        let mut blinding_rng = rand::thread_rng();
 
-        // Prover allocates variables and adds constraints to the constraint system
-        let (input_vars, output_vars) = variables.split_at(k);
-        KShuffleGadget::fill_cs(&mut prover_cs, input_vars, output_vars);
+        let (input_commitments, input_vars): (Vec<_>, Vec<_>) = input
+            .into_iter()
+            .map(|v| prover.commit(*v, Scalar::random(&mut blinding_rng)))
+            .unzip();
 
-        // Prover generates proof
-        let proof = prover_cs.prove()?;
-        Ok((proof, commitments))
+        let (output_commitments, output_vars): (Vec<_>, Vec<_>) = output
+            .into_iter()
+            .map(|v| prover.commit(*v, Scalar::random(&mut blinding_rng)))
+            .unzip();
+
+        let proof = prover.prove(|cs| {
+            Self::fill_cs(cs, &input_vars, &output_vars);
+            Ok(())
+        })?;
+
+        Ok((proof, input_commitments, output_commitments))
     }
 
     pub fn verify<'a, 'b>(
@@ -152,20 +157,30 @@ impl KShuffleGadget {
         bp_gens: &'b BulletproofGens,
         transcript: &'a mut Transcript,
         proof: &R1CSProof,
-        commitments: &Vec<CompressedRistretto>,
+        input_commitments: &Vec<CompressedRistretto>,
+        output_commitments: &Vec<CompressedRistretto>,
     ) -> Result<(), R1CSError> {
-        let k = commitments.len() / 2;
+        // Apply a domain separator with the shuffle parameters to the transcript
+        let k = input_commitments.len();
+        transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
+        transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        // Verifier makes a `ConstraintSystem` instance representing a shuffle gadget
-        let (mut verifier_cs, variables) =
-            VerifierCS::new(&bp_gens, &pc_gens, transcript, commitments.to_vec());
+        let mut verifier = Verifier::new(&bp_gens, &pc_gens, transcript);
 
-        // Verifier allocates variables and adds constraints to the constraint system
-        let (input_vars, output_vars) = variables.split_at(k);
-        KShuffleGadget::fill_cs(&mut verifier_cs, input_vars, output_vars);
+        let input_vars: Vec<_> = input_commitments
+            .iter()
+            .map(|commitment| verifier.commit(*commitment))
+            .collect();
 
-        // Verifier verifies proof
-        verifier_cs.verify(&proof)
+        let output_vars: Vec<_> = output_commitments
+            .iter()
+            .map(|commitment| verifier.commit(*commitment))
+            .collect();
+
+        verifier.verify(&proof, |cs| {
+            Self::fill_cs(cs, &input_vars, &output_vars);
+            Ok(())
+        })
     }
 }
 
@@ -237,7 +252,7 @@ fn kshuffle_verify_helper(k: usize, c: &mut Criterion) {
         let pc_gens = PedersenGens::default();
         let bp_gens = BulletproofGens::new(128, 1);
         let mut prover_transcript = Transcript::new(b"ShuffleTest");
-        let (proof, commitments) =
+        let (proof, in_commitments, out_commitments) =
             KShuffleGadget::prove(&pc_gens, &bp_gens, &mut prover_transcript, &input, &output)
                 .unwrap();
 
@@ -249,7 +264,8 @@ fn kshuffle_verify_helper(k: usize, c: &mut Criterion) {
                 &bp_gens,
                 &mut verifier_transcript,
                 &proof,
-                &commitments,
+                &in_commitments,
+                &out_commitments,
             )
             .unwrap();
         })

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -12,7 +12,7 @@ mod verifier;
 pub use self::constraint_system::ConstraintSystem;
 pub use self::linear_combination::{LinearCombination, Variable};
 pub use self::proof::R1CSProof;
-pub use self::prover::ProverCS;
-pub use self::verifier::VerifierCS;
+pub use self::prover::Prover;
+pub use self::verifier::Verifier;
 
 pub use errors::R1CSError;

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -13,19 +13,25 @@ use generators::{BulletproofGens, PedersenGens};
 use inner_product_proof::InnerProductProof;
 use transcript::TranscriptProtocol;
 
+/// An entry point for creating a R1CS proof.
+///
+/// The lifecycle of a `Prover` is as follows. The proving code
+/// commits high-level variables and their blinding factors `(v, v_blinding)`,
+/// `Prover` generates commitments, adds them to the transcript and returns
+/// corresponding variables (which the user can organize as necessary).
+///
+/// After all variables are committed, the user calls `prove` which consumes `Prover`
+/// and provides `ProverCS` as an argument to a closure which builds the constraint system.
+/// The `prove` method returns the complete proof.
+pub struct Prover<'a, 'b> {
+    /// Number of high-level variables
+    m: u64,
+
+    /// Constraint system implementation
+    cs: ProverCS<'a, 'b>,
+}
+
 /// A [`ConstraintSystem`] implementation for use by the prover.
-///
-/// The lifecycle of a `ProverCS` is as follows.  The proving code
-/// assembles openings `(v, v_blinding)` to the commitments to the
-/// inputs to the constraint system, then passes them, along with
-/// generators and a transcript, to [`ProverCS::new`].  This
-/// initializes the `ProverCS` and returns [`Variable`]s corresponding
-/// to the inputs.
-///
-/// The prover can then pass the `ProverCS` and the external variables
-/// to gadget code to build the constraints, before finally calling
-/// [`ProverCS::prove`], which consumes the `ProverCS`, synthesizes
-/// the witness, and constructs the proof.
 pub struct ProverCS<'a, 'b> {
     transcript: &'a mut Transcript,
     bp_gens: &'b BulletproofGens,
@@ -126,7 +132,7 @@ impl<'a, 'b> ConstraintSystem for ProverCS<'a, 'b> {
     }
 }
 
-impl<'a, 'b> ProverCS<'a, 'b> {
+impl<'a, 'b> Prover<'a, 'b> {
     /// Construct an empty constraint system with specified external
     /// input variables.
     ///
@@ -144,8 +150,38 @@ impl<'a, 'b> ProverCS<'a, 'b> {
     /// transcript.  This ensures that the transcript cannot be
     /// altered except by the `ProverCS` before proving is complete.
     ///
+    /// # Returns
+    ///
+    /// Returns a new `Prover` instance.
+    pub fn new(
+        bp_gens: &'b BulletproofGens,
+        pc_gens: &'b PedersenGens,
+        transcript: &'a mut Transcript,
+    ) -> Self {
+        transcript.r1cs_domain_sep();
+
+        Prover {
+            m: 0,
+            cs: ProverCS {
+                pc_gens,
+                bp_gens,
+                transcript,
+                v: Vec::new(),
+                v_blinding: Vec::new(),
+                constraints: Vec::new(),
+                a_L: Vec::new(),
+                a_R: Vec::new(),
+                a_O: Vec::new(),
+            },
+        }
+    }
+
+    /// Creates commitment to a high-level variable and adds it to the transcript.
+    ///
+    /// # Inputs
+    ///
     /// The `v` and `v_blinding` parameters are openings to the
-    /// commitments to the external variables for the constraint
+    /// commitment to the external variable for the constraint
     /// system.  Passing the opening (the value together with the
     /// blinding factor) makes it possible to reference pre-existing
     /// commitments in the constraint system.  All external variables
@@ -155,55 +191,44 @@ impl<'a, 'b> ProverCS<'a, 'b> {
     ///
     /// # Returns
     ///
-    /// Returns a tuple `(cs, vars, commitments)`.
-    ///
-    /// The first element is the newly constructed constraint system.
-    ///
-    /// The second element is a list of [`Variable`]s corresponding to
-    /// the external inputs, which can be used to form constraints.
-    ///
-    /// The third element is a list of the Pedersen commitments to the
-    /// external inputs, returned for convenience.
-    pub fn new(
-        bp_gens: &'b BulletproofGens,
-        pc_gens: &'b PedersenGens,
-        transcript: &'a mut Transcript,
-        v: Vec<Scalar>,
-        v_blinding: Vec<Scalar>,
-    ) -> (Self, Vec<Variable>, Vec<CompressedRistretto>) {
-        // Check that the input lengths are consistent
-        assert_eq!(v.len(), v_blinding.len());
-        let m = v.len();
-        transcript.r1cs_domain_sep(m as u64);
+    /// Returns a pair of a Pedersen commitment (as a compressed Ristretto point),
+    /// and a [`Variable`] corresponding to it, which can be used to form constraints.
+    pub fn commit(&mut self, v: Scalar, v_blinding: Scalar) -> (CompressedRistretto, Variable) {
+        let i = self.m as usize;
+        self.m += 1;
+        self.cs.v.push(v);
+        self.cs.v_blinding.push(v_blinding);
 
-        let mut variables = Vec::with_capacity(m);
-        let mut commitments = Vec::with_capacity(m);
+        // Add the commitment to the transcript.
+        let V = self.cs.pc_gens.commit(v, v_blinding).compress();
+        self.cs.transcript.commit_point(b"V", &V);
 
-        for i in 0..m {
-            // Generate pedersen commitment and commit it to the transcript
-            let V = pc_gens.commit(v[i], v_blinding[i]).compress();
-            transcript.commit_point(b"V", &V);
-            commitments.push(V);
-
-            // Allocate and return a variable for v_i
-            variables.push(Variable::Committed(i));
-        }
-
-        let cs = ProverCS {
-            pc_gens,
-            bp_gens,
-            transcript,
-            v,
-            v_blinding,
-            constraints: vec![],
-            a_L: vec![],
-            a_R: vec![],
-            a_O: vec![],
-        };
-
-        (cs, variables, commitments)
+        (V, Variable::Committed(i))
     }
 
+    /// Consume the `Prover`, provide the `ConstraintSystem` implementation to the closure,
+    /// and produce a proof.
+    pub fn prove<F>(self, cs_builder: F) -> Result<R1CSProof, R1CSError>
+    where
+        F: FnOnce(&mut ProverCS<'a, 'b>) -> Result<(), R1CSError>,
+    {
+        let mut cs = self.cs;
+
+        // Commit a length suffix for the number of variables.
+        // We cannot do this in advance because user can commit variables one-by-one,
+        // but this suffix provides safe disambiguation because each variable
+        // is prefixed with a separate label.
+        cs.transcript.commit_u64(b"m", self.m);
+
+        // Let the user's closure to fill in constraints.
+        cs_builder(&mut cs)?;
+
+        // Make a proof.
+        cs.prove()
+    }
+}
+
+impl<'a, 'b> ProverCS<'a, 'b> {
     /// Use a challenge, `z`, to flatten the constraints in the
     /// constraint system into vectors used for proving and
     /// verification.

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -11,7 +11,9 @@ pub trait TranscriptProtocol {
     /// Commit a domain separator for a length-`n` inner product proof.
     fn innerproduct_domain_sep(&mut self, n: u64);
     /// Commit a domain separator for a constraint system.
-    fn r1cs_domain_sep(&mut self, m: u64);
+    fn r1cs_domain_sep(&mut self);
+    /// Commit a 64-bit integer.
+    fn commit_u64(&mut self, label: &'static [u8], n: u64);
     /// Commit a `scalar` with the given `label`.
     fn commit_scalar(&mut self, label: &'static [u8], scalar: &Scalar);
     /// Commit a `point` with the given `label`.
@@ -38,9 +40,12 @@ impl TranscriptProtocol for Transcript {
         self.commit_bytes(b"n", &le_u64(n));
     }
 
-    fn r1cs_domain_sep(&mut self, m: u64) {
+    fn r1cs_domain_sep(&mut self) {
         self.commit_bytes(b"dom-sep", b"r1cs v1");
-        self.commit_bytes(b"m", &le_u64(m));
+    }
+
+    fn commit_u64(&mut self, label: &'static [u8], n: u64) {
+        self.commit_bytes(label, &le_u64(n));
     }
 
     fn commit_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {


### PR DESCRIPTION
Addresses #218.

The API entry points are now `Prover` and `Verifier` types that let you commit high-level variables individually, so that one can organize resulting variables in the way matching the outer protocol (e.g. in tuples). 

The `ProverCS` and `VerifierCS` are provided to the user when `Prover` and `Verifier` are consumed, which ensures that high-level variables cannot be committed during CS construction.

Building a CS happens inside a closure provided to `prove`/`verify` methods, so the user effectively "passes a CS" as an argument to the `prove` or `verify`.