### PR TITLE
Add benchmarks for BulletproofGens and PedersenGens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,10 @@ name = "range_proof"
 harness = false
 
 [[bench]]
+name = "generators"
+harness = false
+
+[[bench]]
 name = "r1cs"
 harness = false
 required-features = ["yoloproofs"]

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -1,0 +1,26 @@
+extern crate bulletproofs;
+use bulletproofs::{BulletproofGens, PedersenGens};
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+fn pc_gens(c: &mut Criterion) {
+    c.bench_function("PedersenGens::new", |b| b.iter(|| PedersenGens::default()));
+}
+
+fn bp_gens(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "BulletproofGens::new",
+        |b, size| b.iter(|| BulletproofGens::new(*size, 1)),
+        (0..10).map(|i| 2 << i),
+    );
+}
+
+criterion_group! {
+    bp,
+    bp_gens,
+    pc_gens,
+}
+
+criterion_main!(bp);


### PR DESCRIPTION
I noticed BulletproofGens is quite slow with larger generator sizes. This commit adds a benchmark for both generators. Figured it may come in handy some day.