### PR TITLE
r1cs: single-variable allocation API + simpler API for assignments

### DIFF
--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -46,7 +46,7 @@ pub trait ConstraintSystem {
     /// ```
     ///
     /// Returns `(left, right, out)` for use in further constraints.
-    fn allocate<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
+    fn allocate_multiplier<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
     where
         F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>;
 

--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -41,7 +41,7 @@ pub trait ConstraintSystem {
 
     /// Allocate a single variable.
     ///
-    /// This either allocates a new multiplier and returns it’s `left` variable,
+    /// This either allocates a new multiplier and returns its `left` variable,
     /// or returns a `right` variable of a multiplier previously allocated by this method.
     /// The output of a multiplier is assigned on a even call, when `right` is assigned.
     ///

--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -60,7 +60,10 @@ pub trait ConstraintSystem {
     /// ```
     ///
     /// Returns `(left, right, out)` for use in further constraints.
-    fn allocate_multiplier<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
+    fn allocate_multiplier<F>(
+        &mut self,
+        assign_fn: F,
+    ) -> Result<(Variable, Variable, Variable), R1CSError>
     where
         F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>;
 

--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -49,9 +49,7 @@ pub trait ConstraintSystem {
     /// has the `right` assigned to zero and all its variables committed.
     ///
     /// Returns unconstrained `Variable` for use in further constraints.
-    fn allocate<F>(&mut self, assign_fn: F) -> Result<Variable, R1CSError>
-    where
-        F: FnOnce() -> Result<Scalar, R1CSError>;
+    fn allocate(&mut self, assignment: Option<Scalar>) -> Result<Variable, R1CSError>;
 
     /// Allocate variables `left`, `right`, and `out`
     /// with the implicit constraint that
@@ -60,12 +58,10 @@ pub trait ConstraintSystem {
     /// ```
     ///
     /// Returns `(left, right, out)` for use in further constraints.
-    fn allocate_multiplier<F>(
+    fn allocate_multiplier(
         &mut self,
-        assign_fn: F,
-    ) -> Result<(Variable, Variable, Variable), R1CSError>
-    where
-        F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>;
+        input_assignments: Option<(Scalar, Scalar)>,
+    ) -> Result<(Variable, Variable, Variable), R1CSError>;
 
     /// Enforce the explicit constraint that
     /// ```text

--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -39,6 +39,20 @@ pub trait ConstraintSystem {
         right: LinearCombination,
     ) -> (Variable, Variable, Variable);
 
+    /// Allocate a single variable.
+    ///
+    /// This either allocates a new multiplier and returns it’s `left` variable,
+    /// or returns a `right` variable of a multiplier previously allocated by this method.
+    /// The output of a multiplier is assigned on a even call, when `right` is assigned.
+    ///
+    /// When CS is committed at the end of the first or second phase, the half-assigned multiplier
+    /// has the `right` assigned to zero and all its variables committed.
+    ///
+    /// Returns unconstrained `Variable` for use in further constraints.
+    fn allocate<F>(&mut self, assign_fn: F) -> Result<Variable, R1CSError>
+    where
+        F: FnOnce() -> Result<Scalar, R1CSError>;
+
     /// Allocate variables `left`, `right`, and `out`
     /// with the implicit constraint that
     /// ```text

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -350,6 +350,9 @@ impl<'a, 'b> Prover<'a, 'b> {
     /// Calls all remembered callbacks with an API that
     /// allows generating challenge scalars.
     fn create_randomized_constraints(mut self) -> Result<Self, R1CSError> {
+        // Clear the pending multiplier (if any) because it was committed into A_L/A_R/S.
+        self.pending_multiplier = None;
+
         // Note: the wrapper could've used &mut instead of ownership,
         // but specifying lifetimes for boxed closures is not going to be nice,
         // so we move the self into wrapper and then move it back out afterwards.
@@ -414,8 +417,6 @@ impl<'a, 'b> Prover<'a, 'b> {
         let mut s_L1: Vec<Scalar> = (0..n1).map(|_| Scalar::random(&mut rng)).collect();
         let mut s_R1: Vec<Scalar> = (0..n1).map(|_| Scalar::random(&mut rng)).collect();
 
-        self.pending_multiplier = None;
-
         // A_I = <a_L, G> + <a_R, H> + i_blinding * B_blinding
         let A_I1 = RistrettoPoint::multiscalar_mul(
             iter::once(&i_blinding1)
@@ -472,8 +473,6 @@ impl<'a, 'b> Prover<'a, 'b> {
 
         let mut s_L2: Vec<Scalar> = (0..n2).map(|_| Scalar::random(&mut rng)).collect();
         let mut s_R2: Vec<Scalar> = (0..n2).map(|_| Scalar::random(&mut rng)).collect();
-
-        self.pending_multiplier = None;
 
         // A_I = <a_L, G> + <a_R, H> + i_blinding * B_blinding
         let A_I2 = RistrettoPoint::multiscalar_mul(

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -45,7 +45,7 @@ pub struct Prover<'a, 'b> {
     deferred_constraints: Vec<Box<Fn(&mut RandomizingProver<'a, 'b>) -> Result<(), R1CSError>>>,
 
     /// Index of a pending multiplier that's not fully assigned yet.
-    pending_multiplier: Option<usize>
+    pending_multiplier: Option<usize>,
 }
 
 /// Prover in the randomizing phase.
@@ -128,7 +128,7 @@ impl<'a, 'b> ConstraintSystem for Prover<'a, 'b> {
                 self.a_R.push(Scalar::zero());
                 self.a_O.push(Scalar::zero());
                 Ok(Variable::MultiplierLeft(i))
-            },
+            }
             Some(i) => {
                 self.pending_multiplier = None;
                 self.a_R[i] = scalar;
@@ -138,7 +138,10 @@ impl<'a, 'b> ConstraintSystem for Prover<'a, 'b> {
         }
     }
 
-    fn allocate_multiplier<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
+    fn allocate_multiplier<F>(
+        &mut self,
+        assign_fn: F,
+    ) -> Result<(Variable, Variable, Variable), R1CSError>
     where
         F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>,
     {
@@ -184,12 +187,15 @@ impl<'a, 'b> ConstraintSystem for RandomizingProver<'a, 'b> {
 
     fn allocate<F>(&mut self, assign_fn: F) -> Result<Variable, R1CSError>
     where
-        F: FnOnce() -> Result<Scalar, R1CSError>
+        F: FnOnce() -> Result<Scalar, R1CSError>,
     {
         self.prover.allocate(assign_fn)
     }
 
-    fn allocate_multiplier<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
+    fn allocate_multiplier<F>(
+        &mut self,
+        assign_fn: F,
+    ) -> Result<(Variable, Variable, Variable), R1CSError>
     where
         F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>,
     {
@@ -253,6 +259,7 @@ impl<'a, 'b> Prover<'a, 'b> {
             a_R: Vec::new(),
             a_O: Vec::new(),
             deferred_constraints: Vec::new(),
+            pending_multiplier: None,
         }
     }
 

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -155,11 +155,11 @@ impl<'a, 'b> ConstraintSystem for RandomizingProver<'a, 'b> {
         self.prover.multiply(left, right)
     }
 
-    fn allocate<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
+    fn allocate_multiplier<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
     where
         F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>,
     {
-        self.prover.allocate(assign_fn)
+        self.prover.allocate_multiplier(assign_fn)
     }
 
     fn constrain(&mut self, lc: LinearCombination) {

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -122,11 +122,11 @@ impl<'a, 'b> ConstraintSystem for RandomizingVerifier<'a, 'b> {
         self.verifier.multiply(left, right)
     }
 
-    fn allocate<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
+    fn allocate_multiplier<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
     where
         F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>,
     {
-        self.verifier.allocate(assign_fn)
+        self.verifier.allocate_multiplier(assign_fn)
     }
 
     fn constrain(&mut self, lc: LinearCombination) {

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -83,10 +83,7 @@ impl<'a, 'b> ConstraintSystem for Verifier<'a, 'b> {
         (l_var, r_var, o_var)
     }
 
-    fn allocate<F>(&mut self, _: F) -> Result<Variable, R1CSError>
-    where
-        F: FnOnce() -> Result<Scalar, R1CSError>,
-    {
+    fn allocate(&mut self, _: Option<Scalar>) -> Result<Variable, R1CSError> {
         match self.pending_multiplier {
             None => {
                 let i = self.num_vars;
@@ -101,10 +98,10 @@ impl<'a, 'b> ConstraintSystem for Verifier<'a, 'b> {
         }
     }
 
-    fn allocate_multiplier<F>(&mut self, _: F) -> Result<(Variable, Variable, Variable), R1CSError>
-    where
-        F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>,
-    {
+    fn allocate_multiplier(
+        &mut self,
+        _: Option<(Scalar, Scalar)>,
+    ) -> Result<(Variable, Variable, Variable), R1CSError> {
         let var = self.num_vars;
         self.num_vars += 1;
 
@@ -143,21 +140,15 @@ impl<'a, 'b> ConstraintSystem for RandomizingVerifier<'a, 'b> {
         self.verifier.multiply(left, right)
     }
 
-    fn allocate<F>(&mut self, assign_fn: F) -> Result<Variable, R1CSError>
-    where
-        F: FnOnce() -> Result<Scalar, R1CSError>,
-    {
-        self.verifier.allocate(assign_fn)
+    fn allocate(&mut self, assignment: Option<Scalar>) -> Result<Variable, R1CSError> {
+        self.verifier.allocate(assignment)
     }
 
-    fn allocate_multiplier<F>(
+    fn allocate_multiplier(
         &mut self,
-        assign_fn: F,
-    ) -> Result<(Variable, Variable, Variable), R1CSError>
-    where
-        F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>,
-    {
-        self.verifier.allocate_multiplier(assign_fn)
+        input_assignments: Option<(Scalar, Scalar)>,
+    ) -> Result<(Variable, Variable, Variable), R1CSError> {
+        self.verifier.allocate_multiplier(input_assignments)
     }
 
     fn constrain(&mut self, lc: LinearCombination) {

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -302,6 +302,9 @@ impl<'a, 'b> Verifier<'a, 'b> {
     /// Calls all remembered callbacks with an API that
     /// allows generating challenge scalars.
     fn create_randomized_constraints(mut self) -> Result<Self, R1CSError> {
+        // Clear the pending multiplier (if any) because it was committed into A_L/A_R/S.
+        self.pending_multiplier = None;
+
         // Note: the wrapper could've used &mut instead of ownership,
         // but specifying lifetimes for boxed closures is not going to be nice,
         // so we move the self into wrapper and then move it back out afterwards.

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -44,7 +44,7 @@ pub struct Verifier<'a, 'b> {
     deferred_constraints: Vec<Box<Fn(&mut RandomizingVerifier<'a, 'b>) -> Result<(), R1CSError>>>,
 
     /// Index of a pending multiplier that's not fully assigned yet.
-    pending_multiplier: Option<usize>
+    pending_multiplier: Option<usize>,
 }
 
 /// Verifier in the randomizing phase.
@@ -83,7 +83,7 @@ impl<'a, 'b> ConstraintSystem for Verifier<'a, 'b> {
         (l_var, r_var, o_var)
     }
 
-    fn allocate<F>(&mut self, assign_fn: F) -> Result<Variable, R1CSError>
+    fn allocate<F>(&mut self, _: F) -> Result<Variable, R1CSError>
     where
         F: FnOnce() -> Result<Scalar, R1CSError>,
     {
@@ -93,7 +93,7 @@ impl<'a, 'b> ConstraintSystem for Verifier<'a, 'b> {
                 self.num_vars += 1;
                 self.pending_multiplier = Some(i);
                 Ok(Variable::MultiplierLeft(i))
-            },
+            }
             Some(i) => {
                 self.pending_multiplier = None;
                 Ok(Variable::MultiplierRight(i))
@@ -145,12 +145,15 @@ impl<'a, 'b> ConstraintSystem for RandomizingVerifier<'a, 'b> {
 
     fn allocate<F>(&mut self, assign_fn: F) -> Result<Variable, R1CSError>
     where
-        F: FnOnce() -> Result<Scalar, R1CSError>
+        F: FnOnce() -> Result<Scalar, R1CSError>,
     {
         self.verifier.allocate(assign_fn)
     }
 
-    fn allocate_multiplier<F>(&mut self, assign_fn: F) -> Result<(Variable, Variable, Variable), R1CSError>
+    fn allocate_multiplier<F>(
+        &mut self,
+        assign_fn: F,
+    ) -> Result<(Variable, Variable, Variable), R1CSError>
     where
         F: FnOnce() -> Result<(Scalar, Scalar, Scalar), R1CSError>,
     {
@@ -222,6 +225,7 @@ impl<'a, 'b> Verifier<'a, 'b> {
             V: Vec::new(),
             constraints: Vec::new(),
             deferred_constraints: Vec::new(),
+            pending_multiplier: None,
         }
     }
 

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -358,3 +358,93 @@ fn example_gadget_serialization_test() {
     // (3 + 4) * (6 + 1) != (40 + 10)
     assert!(example_gadget_roundtrip_serialization_helper(3, 4, 6, 1, 40, 10).is_err());
 }
+
+// Range Proof gadget
+
+/// Enforces that the quantity of v is in the range [0, 2^n).
+pub fn range_proof<CS: ConstraintSystem>(
+    cs: &mut CS,
+    mut v: LinearCombination,
+    v_assignment: Option<u64>,
+    n: usize,
+) -> Result<(), R1CSError> {
+    let mut exp_2 = Scalar::one();
+    for i in 0..n {
+        // Create low-level variables and add them to constraints
+        let (a, b, o) = cs.allocate_multiplier(|| {
+            let q = v_assignment.ok_or(R1CSError::MissingAssignment)?;
+            let bit: u64 = (q >> i) & 1;
+            Ok(((1 - bit).into(), bit.into(), Scalar::zero()))
+        })?;
+
+        // Enforce a * b = 0, so one of (a,b) is zero
+        cs.constrain(o.into());
+
+        // Enforce that a = 1 - b, so they both are 1 or 0.
+        cs.constrain(a + (b - 1u64));
+
+        // Add `-b_i*2^i` to the linear combination
+        // in order to form the following constraint by the end of the loop:
+        // v = Sum(b_i * 2^i, i = 0..n-1)
+        v = v - b * exp_2;
+
+        exp_2 = exp_2 + exp_2;
+    }
+
+    // Enforce that v = Sum(b_i * 2^i, i = 0..n-1)
+    cs.constrain(v);
+
+    Ok(())
+}
+
+#[test]
+fn range_proof_gadget() {
+    use rand::rngs::OsRng;
+    use rand::Rng;
+
+    let mut rng = OsRng::new().unwrap();
+    let m = 3; // number of values to test per `n`
+
+    for n in [2, 10, 32, 63].iter() {
+        let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
+        let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min, max)).collect();
+        for v in values {
+            assert!(range_proof_helper(v.into(), *n).is_ok());
+        }
+        assert!(range_proof_helper((max + 1).into(), *n).is_err());
+    }
+}
+
+fn range_proof_helper(v_val: u64, n: usize) -> Result<(), R1CSError> {
+    // Common
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new(128, 1);
+
+    // Prover's scope
+    let (proof, commitment) = {
+        // Prover makes a `ConstraintSystem` instance representing a range proof gadget
+        let mut prover_transcript = Transcript::new(b"RangeProofTest");
+        let mut rng = rand::thread_rng();
+
+        let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
+
+        let (com, var) = prover.commit(v_val.into(), Scalar::random(&mut rng));
+        assert!(range_proof(&mut prover, var.into(), Some(v_val), n).is_ok());
+
+        let proof = prover.prove()?;
+
+        (proof, com)
+    };
+
+    // Verifier makes a `ConstraintSystem` instance representing a merge gadget
+    let mut verifier_transcript = Transcript::new(b"RangeProofTest");
+    let mut verifier = Verifier::new(&bp_gens, &pc_gens, &mut verifier_transcript);
+
+    let var = verifier.commit(commitment);
+
+    // Verifier adds constraints to the constraint system
+    assert!(range_proof(&mut verifier, var.into(), None, n).is_ok());
+
+    // Verifier verifies proof
+    Ok(verifier.verify(&proof)?)
+}

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -371,11 +371,10 @@ pub fn range_proof<CS: ConstraintSystem>(
     let mut exp_2 = Scalar::one();
     for i in 0..n {
         // Create low-level variables and add them to constraints
-        let (a, b, o) = cs.allocate_multiplier(|| {
-            let q = v_assignment.ok_or(R1CSError::MissingAssignment)?;
+        let (a, b, o) = cs.allocate_multiplier(v_assignment.map(|q| {
             let bit: u64 = (q >> i) & 1;
-            Ok(((1 - bit).into(), bit.into(), Scalar::zero()))
-        })?;
+            ((1 - bit).into(), bit.into())
+        }))?;
 
         // Enforce a * b = 0, so one of (a,b) is zero
         cs.constrain(o.into());


### PR DESCRIPTION
This adds efficient and clean API for allocating one variable at a time.

Here is how it simplifies the code in Spacesuit and ZkVM: https://github.com/interstellar/slingshot/pull/211

Plus, the assignments are provided simply as `Option<Scalar>` and `Option<(Scalar,Scalar)>` to make code look nicer. The overhead in verifier of checking for `None` and not doing `Option::map` or something in the gadget code should be negligible.

Closes #206