### PR TITLE
r1cs: provide BP generators later in the proving/verifying workflow

### DIFF
--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -139,7 +139,7 @@ impl KShuffleGadget {
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        let mut prover = Prover::new(&bp_gens, &pc_gens, transcript);
+        let mut prover = Prover::new(&pc_gens, transcript);
 
         // Construct blinding factors using an RNG.
         // Note: a non-example implementation would want to operate on existing commitments.
@@ -156,7 +156,7 @@ impl KShuffleGadget {
             .unzip();
 
         Self::fill_cs(&mut prover, input_vars, output_vars)?;
-        let proof = prover.prove()?;
+        let proof = prover.prove(&bp_gens)?;
 
         Ok((proof, input_commitments, output_commitments))
     }

--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -174,7 +174,7 @@ impl KShuffleGadget {
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        let mut verifier = Verifier::new(&bp_gens, &pc_gens, transcript);
+        let mut verifier = Verifier::new(transcript);
 
         let input_vars: Vec<_> = input_commitments
             .iter()
@@ -187,7 +187,7 @@ impl KShuffleGadget {
             .collect();
 
         Self::fill_cs(&mut verifier, input_vars, output_vars)?;
-        verifier.verify(proof)
+        verifier.verify(proof, &pc_gens, &bp_gens)
     }
 }
 

--- a/docs/r1cs-docs-example.md
+++ b/docs/r1cs-docs-example.md
@@ -359,7 +359,7 @@ impl ShuffleProof {
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        let mut verifier = Verifier::new(&pc_gens, transcript);
+        let mut verifier = Verifier::new(transcript);
 
         let input_vars: Vec<_> = input_commitments.iter().map(|commitment| {
             verifier.commit(*commitment)
@@ -371,7 +371,7 @@ impl ShuffleProof {
 
         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 
-        verifier.verify(&self.0, &bp_gens)
+        verifier.verify(&self.0, &pc_gens, &bp_gens)
     }
 }
 ```
@@ -499,7 +499,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
 #         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 # 
-#         let mut verifier = Verifier::new(&pc_gens, transcript);
+#         let mut verifier = Verifier::new(transcript);
 # 
 #         let input_vars: Vec<_> = input_commitments.iter().map(|commitment| {
 #             verifier.commit(*commitment)
@@ -511,7 +511,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #
 #         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 #
-#         verifier.verify(&self.0, &bp_gens)
+#         verifier.verify(&self.0, &pc_gens, &bp_gens)
 #     }
 # }
 # fn main() {

--- a/docs/r1cs-docs-example.md
+++ b/docs/r1cs-docs-example.md
@@ -212,7 +212,7 @@ impl ShuffleProof {
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        let mut prover = Prover::new(&bp_gens, &pc_gens, transcript);
+        let mut prover = Prover::new(&pc_gens, transcript);
 
         // Construct blinding factors using an RNG.
         // Note: a non-example implementation would want to operate on existing commitments.
@@ -232,7 +232,7 @@ impl ShuffleProof {
 
         ShuffleProof::gadget(&mut prover, input_vars, output_vars)?;
 
-        let proof = prover.prove()?;
+        let proof = prover.prove(&bp_gens)?;
 
         Ok((ShuffleProof(proof), input_commitments, output_commitments))
     }
@@ -319,7 +319,7 @@ The verifier receives a proof, and a list of committed inputs and outputs, from 
 #         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
 #         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 # 
-#         let mut prover = Prover::new(&bp_gens, &pc_gens, transcript);
+#         let mut prover = Prover::new(&pc_gens, transcript);
 # 
 #         // Construct blinding factors using an RNG.
 #         // Note: a non-example implementation would want to operate on existing commitments.
@@ -339,7 +339,7 @@ The verifier receives a proof, and a list of committed inputs and outputs, from 
 #
 #         ShuffleProof::gadget(&mut prover, input_vars, output_vars)?;
 #
-#         let proof = prover.prove()?;
+#         let proof = prover.prove(&bp_gens)?;
 #
 #         Ok((ShuffleProof(proof), input_commitments, output_commitments))
 #     }
@@ -359,7 +359,7 @@ impl ShuffleProof {
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        let mut verifier = Verifier::new(&bp_gens, &pc_gens, transcript);
+        let mut verifier = Verifier::new(&pc_gens, transcript);
 
         let input_vars: Vec<_> = input_commitments.iter().map(|commitment| {
             verifier.commit(*commitment)
@@ -371,7 +371,7 @@ impl ShuffleProof {
 
         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 
-        verifier.verify(&self.0)
+        verifier.verify(&self.0, &bp_gens)
     }
 }
 ```
@@ -459,7 +459,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
 #         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 # 
-#         let mut prover = Prover::new(&bp_gens, &pc_gens, transcript);
+#         let mut prover = Prover::new(&pc_gens, transcript);
 # 
 #         // Construct blinding factors using an RNG.
 #         // Note: a non-example implementation would want to operate on existing commitments.
@@ -479,7 +479,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #
 #         ShuffleProof::gadget(&mut prover, input_vars, output_vars)?;
 #
-#         let proof = prover.prove()?;
+#         let proof = prover.prove(&bp_gens)?;
 #
 #         Ok((ShuffleProof(proof), input_commitments, output_commitments))
 #     }
@@ -499,7 +499,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
 #         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 # 
-#         let mut verifier = Verifier::new(&bp_gens, &pc_gens, transcript);
+#         let mut verifier = Verifier::new(&pc_gens, transcript);
 # 
 #         let input_vars: Vec<_> = input_commitments.iter().map(|commitment| {
 #             verifier.commit(*commitment)
@@ -511,7 +511,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #
 #         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 #
-#         verifier.verify(&self.0)
+#         verifier.verify(&self.0, &bp_gens)
 #     }
 # }
 # fn main() {

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -358,11 +358,6 @@ impl<'a, 'b> Prover<'a, 'b> {
         Ok(wrapped_self.prover)
     }
 
-    /// Returns a required capacity for BulletproofGens.
-    pub fn required_capacity(&self) -> usize {
-        self.a_L.len()
-    }
-
     /// Consume this `ConstraintSystem` to produce a proof.
     pub fn prove(mut self, bp_gens: &BulletproofGens) -> Result<R1CSProof, R1CSError> {
         use std::iter;

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -358,6 +358,11 @@ impl<'a, 'b> Prover<'a, 'b> {
         Ok(wrapped_self.prover)
     }
 
+    /// Returns a required capacity for BulletproofGens.
+    pub fn required_capacity(&self) -> usize {
+        self.a_L.len()
+    }
+
     /// Consume this `ConstraintSystem` to produce a proof.
     pub fn prove(mut self, bp_gens: &BulletproofGens) -> Result<R1CSProof, R1CSError> {
         use std::iter;

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -23,9 +23,9 @@ use transcript::TranscriptProtocol;
 /// When all constraints are added, the proving code calls `prove`
 /// which consumes the `Prover` instance, samples random challenges
 /// that instantiate the randomized constraints, and creates a complete proof.
-pub struct Prover<'a, 'b> {
-    transcript: &'a mut Transcript,
-    pc_gens: &'b PedersenGens,
+pub struct Prover<'t, 'g> {
+    transcript: &'t mut Transcript,
+    pc_gens: &'g PedersenGens,
     /// The constraints accumulated so far.
     constraints: Vec<LinearCombination>,
     /// Stores assignments to the "left" of multiplication gates
@@ -41,7 +41,7 @@ pub struct Prover<'a, 'b> {
 
     /// This list holds closures that will be called in the second phase of the protocol,
     /// when non-randomized variables are committed.
-    deferred_constraints: Vec<Box<Fn(&mut RandomizingProver<'a, 'b>) -> Result<(), R1CSError>>>,
+    deferred_constraints: Vec<Box<Fn(&mut RandomizingProver<'t, 'g>) -> Result<(), R1CSError>>>,
 
     /// Index of a pending multiplier that's not fully assigned yet.
     pending_multiplier: Option<usize>,
@@ -54,12 +54,12 @@ pub struct Prover<'a, 'b> {
 /// monomorphize the closures for the proving and verifying code.
 /// However, this type cannot be instantiated by the user and therefore can only be used within
 /// the callback provided to `specify_randomized_constraints`.
-pub struct RandomizingProver<'a, 'b> {
-    prover: Prover<'a, 'b>,
+pub struct RandomizingProver<'t, 'g> {
+    prover: Prover<'t, 'g>,
 }
 
 /// Overwrite secrets with null bytes when they go out of scope.
-impl<'a, 'b> Drop for Prover<'a, 'b> {
+impl<'t, 'g> Drop for Prover<'t, 'g> {
     fn drop(&mut self) {
         self.v.clear();
         self.v_blinding.clear();
@@ -82,8 +82,8 @@ impl<'a, 'b> Drop for Prover<'a, 'b> {
     }
 }
 
-impl<'a, 'b> ConstraintSystem for Prover<'a, 'b> {
-    type RandomizedCS = RandomizingProver<'a, 'b>;
+impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
+    type RandomizedCS = RandomizingProver<'t, 'g>;
 
     fn multiply(
         &mut self,
@@ -168,7 +168,7 @@ impl<'a, 'b> ConstraintSystem for Prover<'a, 'b> {
     }
 }
 
-impl<'a, 'b> ConstraintSystem for RandomizingProver<'a, 'b> {
+impl<'t, 'g> ConstraintSystem for RandomizingProver<'t, 'g> {
     type RandomizedCS = Self;
 
     fn multiply(
@@ -202,13 +202,13 @@ impl<'a, 'b> ConstraintSystem for RandomizingProver<'a, 'b> {
     }
 }
 
-impl<'a, 'b> RandomizedConstraintSystem for RandomizingProver<'a, 'b> {
+impl<'t, 'g> RandomizedConstraintSystem for RandomizingProver<'t, 'g> {
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar {
         self.prover.transcript.challenge_scalar(label)
     }
 }
 
-impl<'a, 'b> Prover<'a, 'b> {
+impl<'t, 'g> Prover<'t, 'g> {
     /// Construct an empty constraint system with specified external
     /// input variables.
     ///
@@ -229,7 +229,7 @@ impl<'a, 'b> Prover<'a, 'b> {
     /// # Returns
     ///
     /// Returns a new `Prover` instance.
-    pub fn new(pc_gens: &'b PedersenGens, transcript: &'a mut Transcript) -> Self {
+    pub fn new(pc_gens: &'g PedersenGens, transcript: &'t mut Transcript) -> Self {
         transcript.r1cs_domain_sep();
 
         Prover {

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -310,6 +310,13 @@ impl<'a, 'b> Verifier<'a, 'b> {
         Ok(wrapped_self.verifier)
     }
 
+    /// Returns a required capacity for BulletproofGens.
+    pub fn required_capacity(&self) -> usize {
+        // XXX this does not include multipliers allocated after randomization,
+        // which is only available inside the `verify()` method when it's too late.
+        self.num_vars
+    }
+
     /// Consume this `VerifierCS` and attempt to verify the supplied `proof`.
     pub fn verify(
         mut self,

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -310,13 +310,6 @@ impl<'a, 'b> Verifier<'a, 'b> {
         Ok(wrapped_self.verifier)
     }
 
-    /// Returns a required capacity for BulletproofGens.
-    pub fn required_capacity(&self) -> usize {
-        // XXX this does not include multipliers allocated after randomization,
-        // which is only available inside the `verify()` method when it's too late.
-        self.num_vars
-    }
-
     /// Consume this `VerifierCS` and attempt to verify the supplied `proof`.
     pub fn verify(
         mut self,

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -21,9 +21,8 @@ use transcript::TranscriptProtocol;
 /// When all constraints are added, the verifying code calls `verify`
 /// which consumes the `Verifier` instance, samples random challenges
 /// that instantiate the randomized constraints, and verifies the proof.
-pub struct Verifier<'a, 'b> {
-    pc_gens: &'b PedersenGens,
-    transcript: &'a mut Transcript,
+pub struct Verifier<'t> {
+    transcript: &'t mut Transcript,
     constraints: Vec<LinearCombination>,
 
     /// Records the number of low-level variables allocated in the
@@ -40,7 +39,7 @@ pub struct Verifier<'a, 'b> {
     /// when non-randomized variables are committed.
     /// After that, the option will flip to None and additional calls to `randomize_constraints`
     /// will invoke closures immediately.
-    deferred_constraints: Vec<Box<Fn(&mut RandomizingVerifier<'a, 'b>) -> Result<(), R1CSError>>>,
+    deferred_constraints: Vec<Box<Fn(&mut RandomizingVerifier<'t>) -> Result<(), R1CSError>>>,
 
     /// Index of a pending multiplier that's not fully assigned yet.
     pending_multiplier: Option<usize>,
@@ -53,12 +52,12 @@ pub struct Verifier<'a, 'b> {
 /// monomorphize the closures for the proving and verifying code.
 /// However, this type cannot be instantiated by the user and therefore can only be used within
 /// the callback provided to `specify_randomized_constraints`.
-pub struct RandomizingVerifier<'a, 'b> {
-    verifier: Verifier<'a, 'b>,
+pub struct RandomizingVerifier<'t> {
+    verifier: Verifier<'t>,
 }
 
-impl<'a, 'b> ConstraintSystem for Verifier<'a, 'b> {
-    type RandomizedCS = RandomizingVerifier<'a, 'b>;
+impl<'t> ConstraintSystem for Verifier<'t> {
+    type RandomizedCS = RandomizingVerifier<'t>;
 
     fn multiply(
         &mut self,
@@ -128,7 +127,7 @@ impl<'a, 'b> ConstraintSystem for Verifier<'a, 'b> {
     }
 }
 
-impl<'a, 'b> ConstraintSystem for RandomizingVerifier<'a, 'b> {
+impl<'t> ConstraintSystem for RandomizingVerifier<'t> {
     type RandomizedCS = Self;
 
     fn multiply(
@@ -162,23 +161,17 @@ impl<'a, 'b> ConstraintSystem for RandomizingVerifier<'a, 'b> {
     }
 }
 
-impl<'a, 'b> RandomizedConstraintSystem for RandomizingVerifier<'a, 'b> {
+impl<'t> RandomizedConstraintSystem for RandomizingVerifier<'t> {
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar {
         self.verifier.transcript.challenge_scalar(label)
     }
 }
 
-impl<'a, 'b> Verifier<'a, 'b> {
+impl<'t> Verifier<'t> {
     /// Construct an empty constraint system with specified external
     /// input variables.
     ///
     /// # Inputs
-    ///
-    /// The `bp_gens` and `pc_gens` are generators for Bulletproofs
-    /// and for the Pedersen commitments, respectively.  The
-    /// [`BulletproofGens`] should have `gens_capacity` greater than
-    /// the number of multiplication constraints that will eventually
-    /// be added into the constraint system.
     ///
     /// The `transcript` parameter is a Merlin proof transcript.  The
     /// `VerifierCS` holds onto the `&mut Transcript` until it consumes
@@ -200,11 +193,10 @@ impl<'a, 'b> Verifier<'a, 'b> {
     ///
     /// The second element is a list of [`Variable`]s corresponding to
     /// the external inputs, which can be used to form constraints.
-    pub fn new(pc_gens: &'b PedersenGens, transcript: &'a mut Transcript) -> Self {
+    pub fn new(transcript: &'t mut Transcript) -> Self {
         transcript.r1cs_domain_sep();
 
         Verifier {
-            pc_gens,
             transcript,
             num_vars: 0,
             V: Vec::new(),
@@ -311,10 +303,16 @@ impl<'a, 'b> Verifier<'a, 'b> {
     }
 
     /// Consume this `VerifierCS` and attempt to verify the supplied `proof`.
+    /// The `pc_gens` and `bp_gens` are generators for Pedersen commitments and
+    /// Bulletproofs vector commitments, respectively.  The
+    /// [`BulletproofGens`] should have `gens_capacity` greater than
+    /// the number of multiplication constraints that will eventually
+    /// be added into the constraint system.
     pub fn verify(
         mut self,
         proof: &R1CSProof,
-        bp_gens: &'b BulletproofGens,
+        pc_gens: &PedersenGens,
+        bp_gens: &BulletproofGens,
     ) -> Result<(), R1CSError> {
         // Commit a length _suffix_ for the number of high-level variables.
         // We cannot do this in advance because user can commit variables one-by-one,
@@ -456,8 +454,8 @@ impl<'a, 'b> Verifier<'a, 'b> {
                 .chain(iter::once(proof.S2.decompress()))
                 .chain(self.V.iter().map(|V_i| V_i.decompress()))
                 .chain(T_points.iter().map(|T_i| T_i.decompress()))
-                .chain(iter::once(Some(self.pc_gens.B)))
-                .chain(iter::once(Some(self.pc_gens.B_blinding)))
+                .chain(iter::once(Some(pc_gens.B)))
+                .chain(iter::once(Some(pc_gens.B_blinding)))
                 .chain(gens.G(padded_n).map(|&G_i| Some(G_i)))
                 .chain(gens.H(padded_n).map(|&H_i| Some(H_i)))
                 .chain(proof.ipp_proof.L_vec.iter().map(|L_i| L_i.decompress()))

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -121,7 +121,7 @@ impl ShuffleProof {
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        let mut verifier = Verifier::new(&pc_gens, transcript);
+        let mut verifier = Verifier::new(transcript);
 
         let input_vars: Vec<_> = input_commitments
             .iter()
@@ -135,7 +135,7 @@ impl ShuffleProof {
 
         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 
-        verifier.verify(&self.0, &bp_gens)
+        verifier.verify(&self.0, &pc_gens, &bp_gens)
     }
 }
 
@@ -283,7 +283,7 @@ fn example_gadget_verify(
     let mut transcript = Transcript::new(b"R1CSExampleGadget");
 
     // 1. Create a verifier
-    let mut verifier = Verifier::new(&pc_gens, &mut transcript);
+    let mut verifier = Verifier::new(&mut transcript);
 
     // 2. Commit high-level variables
     let vars: Vec<_> = commitments.iter().map(|V| verifier.commit(*V)).collect();
@@ -301,7 +301,7 @@ fn example_gadget_verify(
 
     // 4. Verify the proof
     verifier
-        .verify(&proof, &bp_gens)
+        .verify(&proof, &pc_gens, &bp_gens)
         .map_err(|_| R1CSError::VerificationError)
 }
 
@@ -425,19 +425,19 @@ fn range_proof_helper(v_val: u64, n: usize) -> Result<(), R1CSError> {
         let mut prover_transcript = Transcript::new(b"RangeProofTest");
         let mut rng = rand::thread_rng();
 
-        let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
+        let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
         let (com, var) = prover.commit(v_val.into(), Scalar::random(&mut rng));
         assert!(range_proof(&mut prover, var.into(), Some(v_val), n).is_ok());
 
-        let proof = prover.prove()?;
+        let proof = prover.prove(&bp_gens)?;
 
         (proof, com)
     };
 
     // Verifier makes a `ConstraintSystem` instance representing a merge gadget
     let mut verifier_transcript = Transcript::new(b"RangeProofTest");
-    let mut verifier = Verifier::new(&bp_gens, &pc_gens, &mut verifier_transcript);
+    let mut verifier = Verifier::new(&mut verifier_transcript);
 
     let var = verifier.commit(commitment);
 
@@ -445,5 +445,5 @@ fn range_proof_helper(v_val: u64, n: usize) -> Result<(), R1CSError> {
     assert!(range_proof(&mut verifier, var.into(), None, n).is_ok());
 
     // Verifier verifies proof
-    Ok(verifier.verify(&proof)?)
+    Ok(verifier.verify(&proof, &pc_gens, &bp_gens)?)
 }

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -82,7 +82,7 @@ impl ShuffleProof {
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        let mut prover = Prover::new(&bp_gens, &pc_gens, transcript);
+        let mut prover = Prover::new(&pc_gens, transcript);
 
         // Construct blinding factors using an RNG.
         // Note: a non-example implementation would want to operate on existing commitments.
@@ -100,7 +100,7 @@ impl ShuffleProof {
 
         ShuffleProof::gadget(&mut prover, input_vars, output_vars)?;
 
-        let proof = prover.prove()?;
+        let proof = prover.prove(&bp_gens)?;
 
         Ok((ShuffleProof(proof), input_commitments, output_commitments))
     }
@@ -121,7 +121,7 @@ impl ShuffleProof {
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
         transcript.commit_bytes(b"k", Scalar::from(k as u64).as_bytes());
 
-        let mut verifier = Verifier::new(&bp_gens, &pc_gens, transcript);
+        let mut verifier = Verifier::new(&pc_gens, transcript);
 
         let input_vars: Vec<_> = input_commitments
             .iter()
@@ -135,7 +135,7 @@ impl ShuffleProof {
 
         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 
-        verifier.verify(&self.0)
+        verifier.verify(&self.0, &bp_gens)
     }
 }
 
@@ -247,7 +247,7 @@ fn example_gadget_proof(
     let mut transcript = Transcript::new(b"R1CSExampleGadget");
 
     // 1. Create a prover
-    let mut prover = Prover::new(bp_gens, pc_gens, &mut transcript);
+    let mut prover = Prover::new(pc_gens, &mut transcript);
 
     // 2. Commit high-level variables
     let (commitments, vars): (Vec<_>, Vec<_>) = [a1, a2, b1, b2, c1]
@@ -267,7 +267,7 @@ fn example_gadget_proof(
     );
 
     // 4. Make a proof
-    let proof = prover.prove()?;
+    let proof = prover.prove(bp_gens)?;
 
     Ok((proof, commitments))
 }
@@ -283,7 +283,7 @@ fn example_gadget_verify(
     let mut transcript = Transcript::new(b"R1CSExampleGadget");
 
     // 1. Create a verifier
-    let mut verifier = Verifier::new(&bp_gens, &pc_gens, &mut transcript);
+    let mut verifier = Verifier::new(&pc_gens, &mut transcript);
 
     // 2. Commit high-level variables
     let vars: Vec<_> = commitments.iter().map(|V| verifier.commit(*V)).collect();
@@ -301,7 +301,7 @@ fn example_gadget_verify(
 
     // 4. Verify the proof
     verifier
-        .verify(&proof)
+        .verify(&proof, &bp_gens)
         .map_err(|_| R1CSError::VerificationError)
 }
 


### PR DESCRIPTION
This change allows users to provide Bulletproofs generators closer to the point where they are needed. This allows a prover, for instance, to know exactly how many multipliers were allocated to prepare a necessary number of generators, and also specify this number in the envelope that holds the proof. Verifier then also has an option to generate a necessary amount of generators based on actual usage, or preallocate as many as specified in the envelope (if not determined by some other factors).

For the verifier, the same thing is done for PedersenGens: since it does not create commitments, but only verifies them.

```rust
let p = Prover::new(&pc_gens, transcript);
...
let proof = p.prove(&bp_gens)?;
```
```rust
let v = Verifier::new(transcript);
...
v.verify(proof, &pc_gens, &bp_gens)?;
```


