### PR TITLE
r1cs: optional serialization for second-phase commitments

### DIFF
--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -3,7 +3,7 @@
 
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::{IsIdentity,Identity};
+use curve25519_dalek::traits::{Identity, IsIdentity};
 
 use errors::R1CSError;
 use inner_product_proof::InnerProductProof;

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -3,6 +3,7 @@
 
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::traits::{IsIdentity,Identity};
 
 use errors::R1CSError;
 use inner_product_proof::InnerProductProof;

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -65,14 +65,15 @@ pub struct R1CSProof {
 }
 
 impl R1CSProof {
-    /// Serializes the proof into a byte array of \\(16 + 2k\\) 32-byte elements,
+    /// Serializes the proof into a byte array of \\((13 or 16) + 2k\\) 32-byte elements,
     /// where \\(k=\lceil \log_2(n) \rceil\\) and \\(n\\) is the number of multiplication gates.
     ///
     /// # Layout
     ///
     /// The layout of the r1cs proof encoding is:
     ///
-    /// * eleven compressed Ristretto points \\(A_{I1},A_{O1},S_1,A_{I2},A_{O2},S_2,T_1,...,T_6\\),
+    /// * 8 or 11 compressed Ristretto points \\(A_{I1},A_{O1},S_1,(A_{I2},A_{O2},S_2),T_1,...,T_6\\)
+    ///   (\\(A_{I2},A_{O2},S_2\\) are skipped if there were no multipliers added in the randomized phase),
     /// * three scalars \\(t_x, \tilde{t}_x, \tilde{e}\\),
     /// * \\(k\\) pairs of compressed Ristretto points \\(L_0,R_0\dots,L_{k-1},R_{k-1}\\),
     /// * two scalars \\(a, b\\).

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -4,7 +4,7 @@ use clear_on_drop::clear::Clear;
 use core::mem;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::{MultiscalarMul,Identity};
+use curve25519_dalek::traits::{Identity, MultiscalarMul};
 use merlin::Transcript;
 
 use super::{ConstraintSystem, LinearCombination, R1CSProof, RandomizedConstraintSystem, Variable};

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -305,21 +305,21 @@ impl<'a, 'b> Verifier<'a, 'b> {
         // Clear the pending multiplier (if any) because it was committed into A_L/A_R/S.
         self.pending_multiplier = None;
 
-        // Note: the wrapper could've used &mut instead of ownership,
-        // but specifying lifetimes for boxed closures is not going to be nice,
-        // so we move the self into wrapper and then move it back out afterwards.
-        let mut callbacks = mem::replace(&mut self.deferred_constraints, Vec::new());
-        let mut wrapped_self = RandomizingVerifier { verifier: self };
-        if callbacks.len() == 0 {
+        if self.deferred_constraints.len() == 0 {
             self.transcript.r1cs_1phase_domain_sep();
+            Ok(self)
         } else {
             self.transcript.r1cs_2phase_domain_sep();
-
+            // Note: the wrapper could've used &mut instead of ownership,
+            // but specifying lifetimes for boxed closures is not going to be nice,
+            // so we move the self into wrapper and then move it back out afterwards.
+            let mut callbacks = mem::replace(&mut self.deferred_constraints, Vec::new());
+            let mut wrapped_self = RandomizingVerifier { verifier: self };
             for callback in callbacks.drain(..) {
                 callback(&mut wrapped_self)?;
             }
+            Ok(wrapped_self.verifier)
         }
-        Ok(wrapped_self.verifier)
     }
 
     /// Consume this `VerifierCS` and attempt to verify the supplied `proof`.

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -310,8 +310,14 @@ impl<'a, 'b> Verifier<'a, 'b> {
         // so we move the self into wrapper and then move it back out afterwards.
         let mut callbacks = mem::replace(&mut self.deferred_constraints, Vec::new());
         let mut wrapped_self = RandomizingVerifier { verifier: self };
-        for callback in callbacks.drain(..) {
-            callback(&mut wrapped_self)?;
+        if callbacks.len() == 0 {
+            self.transcript.r1cs_1phase_domain_sep();
+        } else {
+            self.transcript.r1cs_2phase_domain_sep();
+
+            for callback in callbacks.drain(..) {
+                callback(&mut wrapped_self)?;
+            }
         }
         Ok(wrapped_self.verifier)
     }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -12,6 +12,10 @@ pub trait TranscriptProtocol {
     fn innerproduct_domain_sep(&mut self, n: u64);
     /// Commit a domain separator for a constraint system.
     fn r1cs_domain_sep(&mut self);
+    /// Commit a domain separator for a CS without randomized constraints.
+    fn r1cs_1phase_domain_sep(&mut self);
+    /// Commit a domain separator for a CS with randomized constraints.
+    fn r1cs_2phase_domain_sep(&mut self);
     /// Commit a `scalar` with the given `label`.
     fn commit_scalar(&mut self, label: &'static [u8], scalar: &Scalar);
     /// Commit a `point` with the given `label`.
@@ -40,6 +44,14 @@ impl TranscriptProtocol for Transcript {
 
     fn r1cs_domain_sep(&mut self) {
         self.commit_bytes(b"dom-sep", b"r1cs v1");
+    }
+
+    fn r1cs_1phase_domain_sep(&mut self) {
+        self.commit_bytes(b"dom-sep", b"r1cs-1phase");
+    }
+
+    fn r1cs_2phase_domain_sep(&mut self) {
+        self.commit_bytes(b"dom-sep", b"r1cs-2phase");
     }
 
     fn commit_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {


### PR DESCRIPTION
If there were no second phase allocations, the proof is shorter by 3x32 bytes: second-phase commitments are treated as identity points.

If there were no randomization callbacks, the proof is domain-separated from one with randomization callbacks.

Note: it is possible to use randomized constraints, yet still perform no allocations in the second phase and receive a shorter proof. In this case the two-phase domain separator is still applied.

Closes #242

Alternative: https://github.com/dalek-cryptography/bulletproofs/pull/264