### PR TITLE
add build instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ assert!(
 );
 # }
 ```
+## Building
+
+To compile successfully, you will need to have nightly Rust installed, rather than stable.
+
+You can install nightly Rust with rustup:
+
+```text
+rustup default nightly
+```
 
 ## Tests and Benchmarks
 


### PR DESCRIPTION
In the course of getting started, I noticed that bulletproofs won't compile with stable Rust, but instead requires nightly Rust. Although the compiler was informative enough that I was able to figure it out, it would likely make it easier for other prospective contributors if this were in the README.