### PR TITLE
Rename R1CSProof/R1CSError to Proof/Error to use r1cs:: prefix instead

### DIFF
--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -1,6 +1,6 @@
 extern crate bulletproofs;
 use bulletproofs::r1cs::{
-    ConstraintSystem, Prover, Error, Proof, RandomizedConstraintSystem, Variable, Verifier,
+    ConstraintSystem, Error, Proof, Prover, RandomizedConstraintSystem, Variable, Verifier,
 };
 use bulletproofs::{BulletproofGens, PedersenGens};
 
@@ -126,14 +126,7 @@ impl KShuffleGadget {
         transcript: &'a mut Transcript,
         input: &[Scalar],
         output: &[Scalar],
-    ) -> Result<
-        (
-            Proof,
-            Vec<CompressedRistretto>,
-            Vec<CompressedRistretto>,
-        ),
-        Error,
-    > {
+    ) -> Result<(Proof, Vec<CompressedRistretto>, Vec<CompressedRistretto>), Error> {
         // Apply a domain separator with the shuffle parameters to the transcript
         let k = input.len();
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");

--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -1,6 +1,6 @@
 extern crate bulletproofs;
 use bulletproofs::r1cs::{
-    ConstraintSystem, Prover, R1CSError, R1CSProof, RandomizedConstraintSystem, Variable, Verifier,
+    ConstraintSystem, Prover, Error, Proof, RandomizedConstraintSystem, Variable, Verifier,
 };
 use bulletproofs::{BulletproofGens, PedersenGens};
 
@@ -77,7 +77,7 @@ impl KShuffleGadget {
         cs: &mut CS,
         x: Vec<Variable>,
         y: Vec<Variable>,
-    ) -> Result<(), R1CSError> {
+    ) -> Result<(), Error> {
         let one = Scalar::one();
 
         assert_eq!(x.len(), y.len());
@@ -128,11 +128,11 @@ impl KShuffleGadget {
         output: &[Scalar],
     ) -> Result<
         (
-            R1CSProof,
+            Proof,
             Vec<CompressedRistretto>,
             Vec<CompressedRistretto>,
         ),
-        R1CSError,
+        Error,
     > {
         // Apply a domain separator with the shuffle parameters to the transcript
         let k = input.len();
@@ -165,10 +165,10 @@ impl KShuffleGadget {
         pc_gens: &'b PedersenGens,
         bp_gens: &'b BulletproofGens,
         transcript: &'a mut Transcript,
-        proof: &R1CSProof,
+        proof: &Proof,
         input_commitments: &Vec<CompressedRistretto>,
         output_commitments: &Vec<CompressedRistretto>,
-    ) -> Result<(), R1CSError> {
+    ) -> Result<(), Error> {
         // Apply a domain separator with the shuffle parameters to the transcript
         let k = input_commitments.len();
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");

--- a/docs/r1cs-docs-example.md
+++ b/docs/r1cs-docs-example.md
@@ -72,10 +72,10 @@ use rand::thread_rng;
 // Shuffle gadget (documented in markdown file)
 
 /// A proof-of-shuffle.
-struct ShuffleProof(R1CSProof);
+struct ShuffleProof(Proof);
 
 impl ShuffleProof {
-    fn gadget<CS: ConstraintSystem>(cs: &mut CS, x: Vec<Variable>, y: Vec<Variable>) -> Result<(),R1CSError> {
+    fn gadget<CS: ConstraintSystem>(cs: &mut CS, x: Vec<Variable>, y: Vec<Variable>) -> Result<(),Error> {
 
         assert_eq!(x.len(), y.len());
         let k = x.len();
@@ -153,10 +153,10 @@ For simplicity, in this example the `prove` function does not take a list of bli
 # // Shuffle gadget (documented in markdown file)
 # 
 # /// A proof-of-shuffle.
-# struct ShuffleProof(R1CSProof);
+# struct ShuffleProof(Proof);
 # 
 # impl ShuffleProof {
-#     fn gadget<CS: ConstraintSystem>(cs: &mut CS, x: Vec<Variable>, y: Vec<Variable>) -> Result<(),R1CSError> {
+#     fn gadget<CS: ConstraintSystem>(cs: &mut CS, x: Vec<Variable>, y: Vec<Variable>) -> Result<(),Error> {
 # 
 #         assert_eq!(x.len(), y.len());
 #         let k = x.len();
@@ -206,7 +206,7 @@ impl ShuffleProof {
         transcript: &'a mut Transcript,
         input: &[Scalar],
         output: &[Scalar],
-    ) -> Result<(ShuffleProof, Vec<CompressedRistretto>, Vec<CompressedRistretto>), R1CSError> {
+    ) -> Result<(ShuffleProof, Vec<CompressedRistretto>, Vec<CompressedRistretto>), Error> {
         // Apply a domain separator with the shuffle parameters to the transcript
         let k = input.len();
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
@@ -241,7 +241,7 @@ impl ShuffleProof {
 
 ## Verifiying a proof
 
-The verifier receives a proof, and a list of committed inputs and outputs, from the prover. It passes these to the `verify` function, which verifies that, given a shuffle proof and a list of committed inputs and outputs, the outputs are a valid reordering of the inputs. The verifier receives a `Result::ok()` if the proof verified correctly and a `Result::error(R1CSError)` otherwise.
+The verifier receives a proof, and a list of committed inputs and outputs, from the prover. It passes these to the `verify` function, which verifies that, given a shuffle proof and a list of committed inputs and outputs, the outputs are a valid reordering of the inputs. The verifier receives a `Result::ok()` if the proof verified correctly and a `Result::error(Error)` otherwise.
 
 
 ```rust
@@ -260,10 +260,10 @@ The verifier receives a proof, and a list of committed inputs and outputs, from 
 # // Shuffle gadget (documented in markdown file)
 # 
 # /// A proof-of-shuffle.
-# struct ShuffleProof(R1CSProof);
+# struct ShuffleProof(Proof);
 # 
 # impl ShuffleProof {
-#     fn gadget<CS: ConstraintSystem>(cs: &mut CS, x: Vec<Variable>, y: Vec<Variable>) -> Result<(),R1CSError> {
+#     fn gadget<CS: ConstraintSystem>(cs: &mut CS, x: Vec<Variable>, y: Vec<Variable>) -> Result<(),Error> {
 # 
 #         assert_eq!(x.len(), y.len());
 #         let k = x.len();
@@ -313,7 +313,7 @@ The verifier receives a proof, and a list of committed inputs and outputs, from 
 #         transcript: &'a mut Transcript,
 #         input: &[Scalar],
 #         output: &[Scalar],
-#     ) -> Result<(ShuffleProof, Vec<CompressedRistretto>, Vec<CompressedRistretto>), R1CSError> {
+#     ) -> Result<(ShuffleProof, Vec<CompressedRistretto>, Vec<CompressedRistretto>), Error> {
 #         // Apply a domain separator with the shuffle parameters to the transcript
 #         let k = input.len();
 #         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
@@ -353,7 +353,7 @@ impl ShuffleProof {
         transcript: &'a mut Transcript,
         input_commitments: &Vec<CompressedRistretto>,
         output_commitments: &Vec<CompressedRistretto>,
-    ) -> Result<(), R1CSError> {
+    ) -> Result<(), Error> {
         // Apply a domain separator with the shuffle parameters to the transcript
         let k = input_commitments.len();
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
@@ -400,10 +400,10 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 # // Shuffle gadget (documented in markdown file)
 # 
 # /// A proof-of-shuffle.
-# struct ShuffleProof(R1CSProof);
+# struct ShuffleProof(Proof);
 # 
 # impl ShuffleProof {
-#     fn gadget<CS: ConstraintSystem>(cs: &mut CS, x: Vec<Variable>, y: Vec<Variable>) -> Result<(),R1CSError> {
+#     fn gadget<CS: ConstraintSystem>(cs: &mut CS, x: Vec<Variable>, y: Vec<Variable>) -> Result<(),Error> {
 # 
 #         assert_eq!(x.len(), y.len());
 #         let k = x.len();
@@ -453,7 +453,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #         transcript: &'a mut Transcript,
 #         input: &[Scalar],
 #         output: &[Scalar],
-#     ) -> Result<(ShuffleProof, Vec<CompressedRistretto>, Vec<CompressedRistretto>), R1CSError> {
+#     ) -> Result<(ShuffleProof, Vec<CompressedRistretto>, Vec<CompressedRistretto>), Error> {
 #         // Apply a domain separator with the shuffle parameters to the transcript
 #         let k = input.len();
 #         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
@@ -493,7 +493,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #         transcript: &'a mut Transcript,
 #         input_commitments: &Vec<CompressedRistretto>,
 #         output_commitments: &Vec<CompressedRistretto>,
-#     ) -> Result<(), R1CSError> {
+#     ) -> Result<(), Error> {
 #         // Apply a domain separator with the shuffle parameters to the transcript
 #         let k = input_commitments.len();
 #         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -93,7 +93,7 @@ pub enum MPCError {
 /// Represents an error during the proving or verifying of a constraint system.
 #[cfg(feature = "yoloproofs")]
 #[derive(Fail, Clone, Debug, Eq, PartialEq)]
-pub enum R1CSError {
+pub enum Error {
     /// Occurs when there are insufficient generators for the proof.
     #[fail(display = "Invalid generators size, too few generators for proof")]
     InvalidGeneratorsLength,
@@ -101,8 +101,8 @@ pub enum R1CSError {
     #[fail(display = "Proof data could not be parsed.")]
     FormatError,
     /// Occurs when verification of an
-    /// [`R1CSProof`](::r1cs::R1CSProof) fails.
-    #[fail(display = "R1CSProof did not verify correctly.")]
+    /// [`Proof`](::r1cs::Proof) fails.
+    #[fail(display = "Proof did not verify correctly.")]
     VerificationError,
 
     /// Occurs when trying to use a missing variable assignment.

--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -1,6 +1,6 @@
 //! Definition of the constraint system trait.
 
-use super::{LinearCombination, Error, Variable};
+use super::{Error, LinearCombination, Variable};
 use curve25519_dalek::scalar::Scalar;
 
 /// The interface for a constraint system, abstracting over the prover

--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -1,12 +1,12 @@
 //! Definition of the constraint system trait.
 
-use super::{LinearCombination, R1CSError, Variable};
+use super::{LinearCombination, Error, Variable};
 use curve25519_dalek::scalar::Scalar;
 
 /// The interface for a constraint system, abstracting over the prover
 /// and verifier's roles.
 ///
-/// Statements to be proved by an [`R1CSProof`](::r1cs::R1CSProof) are specified by
+/// Statements to be proved by an [`Proof`](::r1cs::Proof) are specified by
 /// programmatically constructing constraints.  These constraints need
 /// to be identical between the prover and verifier, since the prover
 /// and verifier need to construct the same statement.
@@ -49,7 +49,7 @@ pub trait ConstraintSystem {
     /// has the `right` assigned to zero and all its variables committed.
     ///
     /// Returns unconstrained `Variable` for use in further constraints.
-    fn allocate(&mut self, assignment: Option<Scalar>) -> Result<Variable, R1CSError>;
+    fn allocate(&mut self, assignment: Option<Scalar>) -> Result<Variable, Error>;
 
     /// Allocate variables `left`, `right`, and `out`
     /// with the implicit constraint that
@@ -61,7 +61,7 @@ pub trait ConstraintSystem {
     fn allocate_multiplier(
         &mut self,
         input_assignments: Option<(Scalar, Scalar)>,
-    ) -> Result<(Variable, Variable, Variable), R1CSError>;
+    ) -> Result<(Variable, Variable, Variable), Error>;
 
     /// Enforce the explicit constraint that
     /// ```text
@@ -88,9 +88,9 @@ pub trait ConstraintSystem {
     ///     // ...
     /// })
     /// ```
-    fn specify_randomized_constraints<F>(&mut self, callback: F) -> Result<(), R1CSError>
+    fn specify_randomized_constraints<F>(&mut self, callback: F) -> Result<(), Error>
     where
-        F: 'static + Fn(&mut Self::RandomizedCS) -> Result<(), R1CSError>;
+        F: 'static + Fn(&mut Self::RandomizedCS) -> Result<(), Error>;
 }
 
 /// Represents a constraint system in the second phase:

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -11,8 +11,8 @@ mod verifier;
 
 pub use self::constraint_system::{ConstraintSystem, RandomizedConstraintSystem};
 pub use self::linear_combination::{LinearCombination, Variable};
-pub use self::proof::R1CSProof;
+pub use self::proof::Proof;
 pub use self::prover::Prover;
 pub use self::verifier::Verifier;
 
-pub use errors::R1CSError;
+pub use errors::Error;

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -14,14 +14,14 @@ use rand::thread_rng;
 // Shuffle gadget (documented in markdown file)
 
 /// A proof-of-shuffle.
-struct ShuffleProof(R1CSProof);
+struct ShuffleProof(Proof);
 
 impl ShuffleProof {
     fn gadget<CS: ConstraintSystem>(
         cs: &mut CS,
         x: Vec<Variable>,
         y: Vec<Variable>,
-    ) -> Result<(), R1CSError> {
+    ) -> Result<(), Error> {
         assert_eq!(x.len(), y.len());
         let k = x.len();
 
@@ -75,7 +75,7 @@ impl ShuffleProof {
             Vec<CompressedRistretto>,
             Vec<CompressedRistretto>,
         ),
-        R1CSError,
+        Error,
     > {
         // Apply a domain separator with the shuffle parameters to the transcript
         let k = input.len();
@@ -115,7 +115,7 @@ impl ShuffleProof {
         transcript: &'a mut Transcript,
         input_commitments: &Vec<CompressedRistretto>,
         output_commitments: &Vec<CompressedRistretto>,
-    ) -> Result<(), R1CSError> {
+    ) -> Result<(), Error> {
         // Apply a domain separator with the shuffle parameters to the transcript
         let k = input_commitments.len();
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
@@ -243,7 +243,7 @@ fn example_gadget_proof(
     b2: u64,
     c1: u64,
     c2: u64,
-) -> Result<(R1CSProof, Vec<CompressedRistretto>), R1CSError> {
+) -> Result<(Proof, Vec<CompressedRistretto>), Error> {
     let mut transcript = Transcript::new(b"R1CSExampleGadget");
 
     // 1. Create a prover
@@ -277,9 +277,9 @@ fn example_gadget_verify(
     pc_gens: &PedersenGens,
     bp_gens: &BulletproofGens,
     c2: u64,
-    proof: R1CSProof,
+    proof: Proof,
     commitments: Vec<CompressedRistretto>,
-) -> Result<(), R1CSError> {
+) -> Result<(), Error> {
     let mut transcript = Transcript::new(b"R1CSExampleGadget");
 
     // 1. Create a verifier
@@ -302,7 +302,7 @@ fn example_gadget_verify(
     // 4. Verify the proof
     verifier
         .verify(&proof)
-        .map_err(|_| R1CSError::VerificationError)
+        .map_err(|_| Error::VerificationError)
 }
 
 fn example_gadget_roundtrip_helper(
@@ -312,7 +312,7 @@ fn example_gadget_roundtrip_helper(
     b2: u64,
     c1: u64,
     c2: u64,
-) -> Result<(), R1CSError> {
+) -> Result<(), Error> {
     // Common
     let pc_gens = PedersenGens::default();
     let bp_gens = BulletproofGens::new(128, 1);
@@ -329,7 +329,7 @@ fn example_gadget_roundtrip_serialization_helper(
     b2: u64,
     c1: u64,
     c2: u64,
-) -> Result<(), R1CSError> {
+) -> Result<(), Error> {
     // Common
     let pc_gens = PedersenGens::default();
     let bp_gens = BulletproofGens::new(128, 1);
@@ -338,7 +338,7 @@ fn example_gadget_roundtrip_serialization_helper(
 
     let proof = proof.to_bytes();
 
-    let proof = R1CSProof::from_bytes(&proof)?;
+    let proof = Proof::from_bytes(&proof)?;
 
     example_gadget_verify(&pc_gens, &bp_gens, c2, proof, commitments)
 }
@@ -367,7 +367,7 @@ pub fn range_proof<CS: ConstraintSystem>(
     mut v: LinearCombination,
     v_assignment: Option<u64>,
     n: usize,
-) -> Result<(), R1CSError> {
+) -> Result<(), Error> {
     let mut exp_2 = Scalar::one();
     for i in 0..n {
         // Create low-level variables and add them to constraints
@@ -414,7 +414,7 @@ fn range_proof_gadget() {
     }
 }
 
-fn range_proof_helper(v_val: u64, n: usize) -> Result<(), R1CSError> {
+fn range_proof_helper(v_val: u64, n: usize) -> Result<(), Error> {
     // Common
     let pc_gens = PedersenGens::default();
     let bp_gens = BulletproofGens::new(128, 1);


### PR DESCRIPTION
This is an attempt to address #247. I'm quite new to Rust, so it's entirely possible that I misunderstood the intent of the issue (this PR is a simple search and replace on the type names). If that's the case, I apologize in advance and would be happy to work on this further.