### PR TITLE
gens: dynamically growable BulletproofGens

### DIFF
--- a/src/generators.rs
+++ b/src/generators.rs
@@ -57,8 +57,6 @@ struct GeneratorsChain {
     reader: Sha3XofReader,
 }
 
-struct GeneratedPoint([u8; 64]);
-
 impl GeneratorsChain {
     /// Creates a chain of generators, determined by the hash of `label`.
     fn new(label: &[u8]) -> Self {
@@ -89,23 +87,17 @@ impl Default for GeneratorsChain {
 }
 
 impl Iterator for GeneratorsChain {
-    type Item = GeneratedPoint;
+    type Item = RistrettoPoint;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut uniform_bytes = [0u8; 64];
         self.reader.read(&mut uniform_bytes);
 
-        Some(GeneratedPoint(uniform_bytes))
+        Some(RistrettoPoint::from_uniform_bytes(&uniform_bytes))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (usize::max_value(), None)
-    }
-}
-
-impl Into<RistrettoPoint> for GeneratedPoint {
-    fn into(self) -> RistrettoPoint {
-        RistrettoPoint::from_uniform_bytes(&self.0)
     }
 }
 
@@ -174,8 +166,7 @@ impl BulletproofGens {
 
                     GeneratorsChain::new(&label)
                         .take(gens_capacity)
-                        .map(|p| p.into())
-                        .collect::<Vec<RistrettoPoint>>()
+                        .collect::<Vec<_>>()
                 })
                 .collect(),
             H_vec: (0..party_capacity)
@@ -186,8 +177,7 @@ impl BulletproofGens {
 
                     GeneratorsChain::new(&label)
                         .take(gens_capacity)
-                        .map(|p| p.into())
-                        .collect::<Vec<RistrettoPoint>>()
+                        .collect::<Vec<_>>()
                 })
                 .collect(),
         }
@@ -219,8 +209,7 @@ impl BulletproofGens {
                 &mut GeneratorsChain::new(&label)
                     .fast_forward(self.gens_capacity)
                     .take(new_capacity - self.gens_capacity)
-                    .map(|p| p.into())
-                    .collect::<Vec<RistrettoPoint>>(),
+                    .collect::<Vec<_>>(),
             );
 
             label[0] = b'H';
@@ -228,8 +217,7 @@ impl BulletproofGens {
                 &mut GeneratorsChain::new(&label)
                     .fast_forward(self.gens_capacity)
                     .take(new_capacity - self.gens_capacity)
-                    .map(|p| p.into())
-                    .collect::<Vec<RistrettoPoint>>(),
+                    .collect::<Vec<_>>(),
             );
         }
         self.gens_capacity = new_capacity;

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -71,7 +71,7 @@ impl GeneratorsChain {
 
     /// Advances the reader n times, squeezing and discarding
     /// the result.
-    fn fast_forward(&mut self, n: usize) -> &mut Self {
+    fn fast_forward(mut self, n: usize) -> Self {
         for _ in 0..n {
             let mut buf = [0u8; 64];
             self.reader.read(&mut buf);
@@ -153,34 +153,14 @@ impl BulletproofGens {
     /// * `party_capacity` is the maximum number of parties that can
     ///    produce an aggregated proof.
     pub fn new(gens_capacity: usize, party_capacity: usize) -> Self {
-        use byteorder::{ByteOrder, LittleEndian};
-
-        BulletproofGens {
+        let mut gens = BulletproofGens {
             gens_capacity,
             party_capacity,
-            G_vec: (0..party_capacity)
-                .map(|i| {
-                    let party_index = i as u32;
-                    let mut label = [b'G', 0, 0, 0, 0];
-                    LittleEndian::write_u32(&mut label[1..5], party_index);
-
-                    GeneratorsChain::new(&label)
-                        .take(gens_capacity)
-                        .collect::<Vec<_>>()
-                })
-                .collect(),
-            H_vec: (0..party_capacity)
-                .map(|i| {
-                    let party_index = i as u32;
-                    let mut label = [b'H', 0, 0, 0, 0];
-                    LittleEndian::write_u32(&mut label[1..5], party_index);
-
-                    GeneratorsChain::new(&label)
-                        .take(gens_capacity)
-                        .collect::<Vec<_>>()
-                })
-                .collect(),
-        }
+            G_vec: (0..party_capacity).map(|_| Vec::new()).collect(),
+            H_vec: (0..party_capacity).map(|_| Vec::new()).collect(),
+        };
+        gens.compute_generators(0, gens_capacity);
+        gens
     }
 
     /// Returns j-th share of generators, with an appropriate
@@ -195,32 +175,28 @@ impl BulletproofGens {
     /// Increases the generators' capacity to the amount specified.
     /// If less than or equal to the current capacity, does nothing.
     pub fn increase_capacity(&mut self, new_capacity: usize) {
-        use byteorder::{ByteOrder, LittleEndian};
-
         if self.gens_capacity >= new_capacity {
             return;
         }
+
+        self.compute_generators(self.gens_capacity, new_capacity - self.gens_capacity);
+        self.gens_capacity = new_capacity;
+    }
+
+    /// Computes a given number of  G and H generators, taking in a
+    /// number of generators to initially skip.
+    fn compute_generators(&mut self, skip: usize, take: usize) {
+        use byteorder::{ByteOrder, LittleEndian};
 
         for i in 0..self.party_capacity {
             let party_index = i as u32;
             let mut label = [b'G', 0, 0, 0, 0];
             LittleEndian::write_u32(&mut label[1..5], party_index);
-            self.G_vec[i].append(
-                &mut GeneratorsChain::new(&label)
-                    .fast_forward(self.gens_capacity)
-                    .take(new_capacity - self.gens_capacity)
-                    .collect::<Vec<_>>(),
-            );
+            self.G_vec[i].extend(&mut GeneratorsChain::new(&label).fast_forward(skip).take(take));
 
             label[0] = b'H';
-            self.H_vec[i].append(
-                &mut GeneratorsChain::new(&label)
-                    .fast_forward(self.gens_capacity)
-                    .take(new_capacity - self.gens_capacity)
-                    .collect::<Vec<_>>(),
-            );
+            self.H_vec[i].extend(&mut GeneratorsChain::new(&label).fast_forward(skip).take(take));
         }
-        self.gens_capacity = new_capacity;
     }
 
     /// Return an iterator over the aggregation of the parties' G generators with given size `n`.
@@ -352,7 +328,7 @@ mod tests {
     }
 
     #[test]
-    fn add_gens_matches() {
+    fn resizing_small_gens_matches_creating_bigger_gens() {
         let gens = BulletproofGens::new(64, 8);
 
         let mut gen_resized = BulletproofGens::new(32, 8);
@@ -370,16 +346,7 @@ mod tests {
         };
 
         helper(64, 8);
-        helper(64, 4);
-        helper(64, 2);
-        helper(64, 1);
         helper(32, 8);
-        helper(32, 4);
-        helper(32, 2);
-        helper(32, 1);
         helper(16, 8);
-        helper(16, 4);
-        helper(16, 2);
-        helper(16, 1);
     }
 }


### PR DESCRIPTION
Adds `add_gens` for `BulletproofGens` so we can extend generators if they are not big enough  