### PR TITLE
r1cs: optional serialization for second-phase commitments with a version tag

### DIFF
--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -12,6 +12,9 @@ use util;
 use serde::de::Visitor;
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 
+const ONE_PHASE_COMMITMENTS: u8 = 0;
+const TWO_PHASE_COMMITMENTS: u8 = 1;
+
 /// A proof of some statement specified by a
 /// [`ConstraintSystem`](::r1cs::ConstraintSystem).
 ///
@@ -71,7 +74,7 @@ impl R1CSProof {
     /// # Layout
     ///
     /// The layout of the r1cs proof encoding is:
-    ///
+    /// * 1 version byte indicating whether the proof contains second-phase commitments or not,
     /// * 8 or 11 compressed Ristretto points \\(A_{I1},A_{O1},S_1,(A_{I2},A_{O2},S_2),T_1,...,T_6\\)
     ///   (\\(A_{I2},A_{O2},S_2\\) are skipped if there were no multipliers added in the randomized phase),
     /// * three scalars \\(t_x, \tilde{t}_x, \tilde{e}\\),
@@ -79,13 +82,16 @@ impl R1CSProof {
     /// * two scalars \\(a, b\\).
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.serialized_size());
-        buf.extend_from_slice(self.A_I1.as_bytes());
-        buf.extend_from_slice(self.A_O1.as_bytes());
-        buf.extend_from_slice(self.S1.as_bytes());
-        if self.A_I2.is_identity() && self.A_O2.is_identity() && self.S2.is_identity() {
-            // Do not serialize second-phase commitments:
-            // challenge-based constraints were not used.
+        if self.missing_phase2_commitments() {
+            buf.push(ONE_PHASE_COMMITMENTS);
+            buf.extend_from_slice(self.A_I1.as_bytes());
+            buf.extend_from_slice(self.A_O1.as_bytes());
+            buf.extend_from_slice(self.S1.as_bytes());
         } else {
+            buf.push(TWO_PHASE_COMMITMENTS);
+            buf.extend_from_slice(self.A_I1.as_bytes());
+            buf.extend_from_slice(self.A_O1.as_bytes());
+            buf.extend_from_slice(self.S1.as_bytes());
             buf.extend_from_slice(self.A_I2.as_bytes());
             buf.extend_from_slice(self.A_O2.as_bytes());
             buf.extend_from_slice(self.S2.as_bytes());
@@ -105,26 +111,37 @@ impl R1CSProof {
 
     /// Returns the size in bytes required to serialize the `R1CSProof`.
     pub fn serialized_size(&self) -> usize {
-        // 14 elements + the ipp
-        14 * 32 + self.ipp_proof.serialized_size()
+        // version tag + (11 or 14) elements + the ipp
+        let elements = if self.missing_phase2_commitments() {
+            11
+        } else {
+            14
+        };
+        1 + elements * 32 + self.ipp_proof.serialized_size()
+    }
+
+    fn missing_phase2_commitments(&self) -> bool {
+        self.A_I2.is_identity() && self.A_O2.is_identity() && self.S2.is_identity()
     }
 
     /// Deserializes the proof from a byte slice.
     ///
     /// Returns an error if the byte slice cannot be parsed into a `R1CSProof`.
-    pub fn from_bytes(mut slice: &[u8]) -> Result<R1CSProof, R1CSError> {
+    pub fn from_bytes(slice: &[u8]) -> Result<R1CSProof, R1CSError> {
+        if slice.len() < 1 {
+            return Err(R1CSError::FormatError);
+        }
+        let version = slice[0];
+        let mut slice = &slice[1..];
+
         if slice.len() % 32 != 0 {
             return Err(R1CSError::FormatError);
         }
-        // number of 32-byte elements in a r1cs proof:
-        // (a) 14 + 2 + 2*lg(n) - with second-phase commitments
-        // (b) 11 + 2 + 2*lg(n) - without second-phase commitments
-        let (used_second_phase, minlength) = if (slice.len() / 32) % 2 == 0 {
-            // even number - we have second-phase commitments
-            (true, 14 * 32)
-        } else {
-            // odd number - we don't have second-phase commitments
-            (false, 11 * 32)
+
+        let minlength = match version {
+            ONE_PHASE_COMMITMENTS => 11 * 32,
+            TWO_PHASE_COMMITMENTS => 14 * 32,
+            _ => return Err(R1CSError::FormatError),
         };
 
         if slice.len() < minlength {
@@ -143,7 +160,7 @@ impl R1CSProof {
         let A_I1 = CompressedRistretto(read32!());
         let A_O1 = CompressedRistretto(read32!());
         let S1 = CompressedRistretto(read32!());
-        let (A_I2, A_O2, S2) = if used_second_phase {
+        let (A_I2, A_O2, S2) = if version == TWO_PHASE_COMMITMENTS {
             (
                 CompressedRistretto(read32!()),
                 CompressedRistretto(read32!()),

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -3,7 +3,7 @@
 
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::{IsIdentity,Identity};
+use curve25519_dalek::traits::{Identity, IsIdentity};
 
 use errors::R1CSError;
 use inner_product_proof::InnerProductProof;

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -3,6 +3,7 @@
 
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::traits::{IsIdentity,Identity};
 
 use errors::R1CSError;
 use inner_product_proof::InnerProductProof;

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -160,17 +160,17 @@ impl R1CSProof {
         let A_I1 = CompressedRistretto(read32!());
         let A_O1 = CompressedRistretto(read32!());
         let S1 = CompressedRistretto(read32!());
-        let (A_I2, A_O2, S2) = if version == TWO_PHASE_COMMITMENTS {
+        let (A_I2, A_O2, S2) = if version == ONE_PHASE_COMMITMENTS {
             (
-                CompressedRistretto(read32!()),
-                CompressedRistretto(read32!()),
-                CompressedRistretto(read32!()),
+                CompressedRistretto::identity(),
+                CompressedRistretto::identity(),
+                CompressedRistretto::identity(),
             )
         } else {
             (
-                CompressedRistretto::identity(),
-                CompressedRistretto::identity(),
-                CompressedRistretto::identity(),
+                CompressedRistretto(read32!()),
+                CompressedRistretto(read32!()),
+                CompressedRistretto(read32!()),
             )
         };
         let T_1 = CompressedRistretto(read32!());

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -65,14 +65,15 @@ pub struct R1CSProof {
 }
 
 impl R1CSProof {
-    /// Serializes the proof into a byte array of \\(16 + 2k\\) 32-byte elements,
+    /// Serializes the proof into a byte array of \\((13 or 16) + 2k\\) 32-byte elements,
     /// where \\(k=\lceil \log_2(n) \rceil\\) and \\(n\\) is the number of multiplication gates.
     ///
     /// # Layout
     ///
     /// The layout of the r1cs proof encoding is:
     ///
-    /// * eleven compressed Ristretto points \\(A_{I1},A_{O1},S_1,A_{I2},A_{O2},S_2,T_1,...,T_6\\),
+    /// * 8 or 11 compressed Ristretto points \\(A_{I1},A_{O1},S_1,(A_{I2},A_{O2},S_2),T_1,...,T_6\\)
+    ///   (\\(A_{I2},A_{O2},S_2\\) are skipped if there were no multipliers added in the randomized phase),
     /// * three scalars \\(t_x, \tilde{t}_x, \tilde{e}\\),
     /// * \\(k\\) pairs of compressed Ristretto points \\(L_0,R_0\dots,L_{k-1},R_{k-1}\\),
     /// * two scalars \\(a, b\\).

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -68,7 +68,7 @@ pub struct R1CSProof {
 }
 
 impl R1CSProof {
-    /// Serializes the proof into a byte array of \\((13 or 16) + 2k\\) 32-byte elements,
+    /// Serializes the proof into a byte array of 1 version byte + \\((13 or 16) + 2k\\) 32-byte elements,
     /// where \\(k=\lceil \log_2(n) \rceil\\) and \\(n\\) is the number of multiplication gates.
     ///
     /// # Layout

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -4,7 +4,7 @@ use clear_on_drop::clear::Clear;
 use core::mem;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::{MultiscalarMul,Identity};
+use curve25519_dalek::traits::{Identity, MultiscalarMul};
 use merlin::Transcript;
 
 use super::{ConstraintSystem, LinearCombination, R1CSProof, RandomizedConstraintSystem, Variable};

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -473,9 +473,9 @@ impl<'a, 'b> Prover<'a, 'b> {
 
         // Commit to the second-phase low-level witness variables
 
-        let has_2nd_phase = n2 > 0;
+        let has_2nd_phase_commitments = n2 > 0;
 
-        let (i_blinding2, o_blinding2, s_blinding2) = if has_2nd_phase {
+        let (i_blinding2, o_blinding2, s_blinding2) = if has_2nd_phase_commitments {
             (
                 Scalar::random(&mut rng),
                 Scalar::random(&mut rng),
@@ -488,7 +488,7 @@ impl<'a, 'b> Prover<'a, 'b> {
         let mut s_L2: Vec<Scalar> = (0..n2).map(|_| Scalar::random(&mut rng)).collect();
         let mut s_R2: Vec<Scalar> = (0..n2).map(|_| Scalar::random(&mut rng)).collect();
 
-        let (A_I2, A_O2, S2) = if has_2nd_phase {
+        let (A_I2, A_O2, S2) = if has_2nd_phase_commitments {
             (
                 // A_I = <a_L, G> + <a_R, H> + i_blinding * B_blinding
                 RistrettoPoint::multiscalar_mul(

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -305,21 +305,21 @@ impl<'a, 'b> Verifier<'a, 'b> {
         // Clear the pending multiplier (if any) because it was committed into A_L/A_R/S.
         self.pending_multiplier = None;
 
-        // Note: the wrapper could've used &mut instead of ownership,
-        // but specifying lifetimes for boxed closures is not going to be nice,
-        // so we move the self into wrapper and then move it back out afterwards.
-        let mut callbacks = mem::replace(&mut self.deferred_constraints, Vec::new());
-        let mut wrapped_self = RandomizingVerifier { verifier: self };
-        if callbacks.len() == 0 {
+        if self.deferred_constraints.len() == 0 {
             self.transcript.r1cs_1phase_domain_sep();
+            Ok(self)
         } else {
             self.transcript.r1cs_2phase_domain_sep();
-
+            // Note: the wrapper could've used &mut instead of ownership,
+            // but specifying lifetimes for boxed closures is not going to be nice,
+            // so we move the self into wrapper and then move it back out afterwards.
+            let mut callbacks = mem::replace(&mut self.deferred_constraints, Vec::new());
+            let mut wrapped_self = RandomizingVerifier { verifier: self };
             for callback in callbacks.drain(..) {
                 callback(&mut wrapped_self)?;
             }
+            Ok(wrapped_self.verifier)
         }
-        Ok(wrapped_self.verifier)
     }
 
     /// Consume this `VerifierCS` and attempt to verify the supplied `proof`.

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -310,8 +310,14 @@ impl<'a, 'b> Verifier<'a, 'b> {
         // so we move the self into wrapper and then move it back out afterwards.
         let mut callbacks = mem::replace(&mut self.deferred_constraints, Vec::new());
         let mut wrapped_self = RandomizingVerifier { verifier: self };
-        for callback in callbacks.drain(..) {
-            callback(&mut wrapped_self)?;
+        if callbacks.len() == 0 {
+            self.transcript.r1cs_1phase_domain_sep();
+        } else {
+            self.transcript.r1cs_2phase_domain_sep();
+
+            for callback in callbacks.drain(..) {
+                callback(&mut wrapped_self)?;
+            }
         }
         Ok(wrapped_self.verifier)
     }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -12,6 +12,10 @@ pub trait TranscriptProtocol {
     fn innerproduct_domain_sep(&mut self, n: u64);
     /// Commit a domain separator for a constraint system.
     fn r1cs_domain_sep(&mut self);
+    /// Commit a domain separator for a CS without randomized constraints.
+    fn r1cs_1phase_domain_sep(&mut self);
+    /// Commit a domain separator for a CS with randomized constraints.
+    fn r1cs_2phase_domain_sep(&mut self);
     /// Commit a `scalar` with the given `label`.
     fn commit_scalar(&mut self, label: &'static [u8], scalar: &Scalar);
     /// Commit a `point` with the given `label`.
@@ -40,6 +44,14 @@ impl TranscriptProtocol for Transcript {
 
     fn r1cs_domain_sep(&mut self) {
         self.commit_bytes(b"dom-sep", b"r1cs v1");
+    }
+
+    fn r1cs_1phase_domain_sep(&mut self) {
+        self.commit_bytes(b"dom-sep", b"r1cs-1phase");
+    }
+
+    fn r1cs_2phase_domain_sep(&mut self) {
+        self.commit_bytes(b"dom-sep", b"r1cs-2phase");
     }
 
     fn commit_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {


### PR DESCRIPTION
If there were no second phase allocations, the proof is shorter by 3x32 bytes: second-phase commitments are treated as identity points.

If there were no randomization callbacks, the proof is domain-separated from one with randomization callbacks.

Note: it is possible to use randomized constraints, yet still perform no allocations in the second phase and receive a shorter proof. In this case the two-phase domain separator is still applied.

Closes #242
Closes #258 

Prior iteration: #258, diff: https://github.com/dalek-cryptography/bulletproofs/compare/oleg/optional-2phase...oleg/optional-2phase-tagged