### PR TITLE
r1cs: lease transcript from CS to bind proof to the data made available later

### DIFF
--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -21,7 +21,7 @@ pub trait ConstraintSystem {
     type RandomizedCS: RandomizedConstraintSystem;
 
     /// Leases the proof transcript to the user, so they can
-    /// add extra data to which the proof must be bound, but that
+    /// add extra data to which the proof must be bound, but which
     /// is not available before creation of the constraint system.
     fn transcript(&mut self) -> &mut Transcript;
 

--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -2,6 +2,7 @@
 
 use super::{LinearCombination, R1CSError, Variable};
 use curve25519_dalek::scalar::Scalar;
+use merlin::Transcript;
 
 /// The interface for a constraint system, abstracting over the prover
 /// and verifier's roles.
@@ -18,6 +19,11 @@ use curve25519_dalek::scalar::Scalar;
 pub trait ConstraintSystem {
     /// Represents a concrete type for the CS in a randomization phase.
     type RandomizedCS: RandomizedConstraintSystem;
+
+    /// Leases the proof transcript to the user, so they can
+    /// add extra data to which the proof must be bound, but that
+    /// is not available before creation of the constraint system.
+    fn transcript(&mut self) -> &mut Transcript;
 
     /// Allocate and constrain multiplication variables.
     ///

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -85,6 +85,10 @@ impl<'t, 'g> Drop for Prover<'t, 'g> {
 impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
     type RandomizedCS = RandomizingProver<'t, 'g>;
 
+    fn transcript(&mut self) -> &mut Transcript {
+        self.transcript
+    }
+
     fn multiply(
         &mut self,
         mut left: LinearCombination,
@@ -170,6 +174,10 @@ impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
 
 impl<'t, 'g> ConstraintSystem for RandomizingProver<'t, 'g> {
     type RandomizedCS = Self;
+
+    fn transcript(&mut self) -> &mut Transcript {
+        self.prover.transcript
+    }
 
     fn multiply(
         &mut self,

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -59,6 +59,10 @@ pub struct RandomizingVerifier<'t> {
 impl<'t> ConstraintSystem for Verifier<'t> {
     type RandomizedCS = RandomizingVerifier<'t>;
 
+    fn transcript(&mut self) -> &mut Transcript {
+        self.transcript
+    }
+
     fn multiply(
         &mut self,
         mut left: LinearCombination,
@@ -129,6 +133,10 @@ impl<'t> ConstraintSystem for Verifier<'t> {
 
 impl<'t> ConstraintSystem for RandomizingVerifier<'t> {
     type RandomizedCS = Self;
+
+    fn transcript(&mut self) -> &mut Transcript {
+        self.verifier.transcript
+    }
 
     fn multiply(
         &mut self,


### PR DESCRIPTION
This adds method `transcript()` to the `ConstraintSystem` trait. The motivation is to allow higher-level protocol to bind the R1CS proof to data that's made available _during_ CS construction, but _not before_.

Example: in [ZkVM](https://github.com/interstellar/slingshot/blob/5377925ac10b13e0f6c958c4d037e13504cc21ce/zkvm/src/prover.rs#L108-L114) the transaction ID is computed via program execution that's also constructing a CS state. By the end of the execution, both the txid and set of constraints are known, and it's safer to bind the proof to the txid, but the transcript is exclusively held by the CS prover. This API allows to borrow the transcript from the CS prover to commit txid, and then complete computation of the R1CS proof.