### PR TITLE
Make closure of challenge phase FnOnce.

### DIFF
--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -106,7 +106,7 @@ pub trait RandomizableConstraintSystem: ConstraintSystem {
     /// ```
     fn specify_randomized_constraints<F>(&mut self, callback: F) -> Result<(), R1CSError>
     where
-        F: 'static + Fn(&mut Self::RandomizedCS) -> Result<(), R1CSError>;
+        F: 'static + FnOnce(&mut Self::RandomizedCS) -> Result<(), R1CSError>;
 }
 
 /// Represents a constraint system in the second phase:

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -37,7 +37,8 @@ pub struct Prover<'g, T: BorrowMut<Transcript>> {
 
     /// This list holds closures that will be called in the second phase of the protocol,
     /// when non-randomized variables are committed.
-    deferred_constraints: Vec<Box<dyn Fn(&mut RandomizingProver<'g, T>) -> Result<(), R1CSError>>>,
+    deferred_constraints:
+        Vec<Box<dyn FnOnce(&mut RandomizingProver<'g, T>) -> Result<(), R1CSError>>>,
 
     /// Index of a pending multiplier that's not fully assigned yet.
     pending_multiplier: Option<usize>,
@@ -182,7 +183,7 @@ impl<'g, T: BorrowMut<Transcript>> RandomizableConstraintSystem for Prover<'g, T
 
     fn specify_randomized_constraints<F>(&mut self, callback: F) -> Result<(), R1CSError>
     where
-        F: 'static + Fn(&mut Self::RandomizedCS) -> Result<(), R1CSError>,
+        F: 'static + FnOnce(&mut Self::RandomizedCS) -> Result<(), R1CSError>,
     {
         self.deferred_constraints.push(Box::new(callback));
         Ok(())

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -43,7 +43,8 @@ pub struct Verifier<T: BorrowMut<Transcript>> {
     /// when non-randomized variables are committed.
     /// After that, the option will flip to None and additional calls to `randomize_constraints`
     /// will invoke closures immediately.
-    deferred_constraints: Vec<Box<dyn Fn(&mut RandomizingVerifier<T>) -> Result<(), R1CSError>>>,
+    deferred_constraints:
+        Vec<Box<dyn FnOnce(&mut RandomizingVerifier<T>) -> Result<(), R1CSError>>>,
 
     /// Index of a pending multiplier that's not fully assigned yet.
     pending_multiplier: Option<usize>,
@@ -134,7 +135,7 @@ impl<T: BorrowMut<Transcript>> RandomizableConstraintSystem for Verifier<T> {
 
     fn specify_randomized_constraints<F>(&mut self, callback: F) -> Result<(), R1CSError>
     where
-        F: 'static + Fn(&mut Self::RandomizedCS) -> Result<(), R1CSError>,
+        F: 'static + FnOnce(&mut Self::RandomizedCS) -> Result<(), R1CSError>,
     {
         self.deferred_constraints.push(Box::new(callback));
         Ok(())


### PR DESCRIPTION
It allows for the challenge phase to accept closures that take some more
context, e.g. moving non-Clone values in the challenge closure.

This works in stable since Rust 1.35; cfr.
https://github.com/rust-lang/rust/issues/28796.

This closes issue #244.

---

~~In other news: I'm not yet happy with the `'static` bound on the closures. Since I'm not yet worried about that kind of performance (just hacking around currently), I'm not going to fight the borrow checker there, yet.~~ Cfr #323 