### PR TITLE
Implement no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rand_chacha = "0.1"
 default = ["std", "avx2_backend"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
-std = ["serde/std", "curve25519-dalek/std", "merlin/std"]
+std = ["rand/std", "serde/std", "curve25519-dalek/std", "merlin/std"]
 alloc = ["rand_core/alloc", "serde/alloc", "curve25519-dalek/alloc", "merlin/alloc"]
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ subtle = { version = "2", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 digest = { version = "0.8", default-features = false }
 rand_core = { version = "0.4", default-features = false }
-rand = { version = "0.5", default-features = false }
+rand = { version = "0.6", default-features = false }
 byteorder = { version = "1", default-features = false }
 serde = { version = "1", default-features = false }
 serde_derive = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,18 @@ keywords = ["cryptography", "crypto", "ristretto", "zero-knowledge", "bulletproo
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
-curve25519-dalek = { version = "1.0.3", features = ["serde"] }
-subtle = "2"
-sha3 = "0.8"
-digest = "0.8"
-rand = "0.6"
-byteorder = "1"
-serde = "1"
-serde_derive = "1"
-failure = "0.1"
-merlin = "1.1"
+cfg-if = "0.1"
+curve25519-dalek = { version = "1.2", default-features = false, features = ["u64_backend", "nightly", "serde"] }
+subtle = { version = "2", default-features = false }
+sha3 = { version = "0.8", default-features = false }
+digest = { version = "0.8", default-features = false }
+rand_core = { version = "0.4", default-features = false }
+rand = { version = "0.5", default-features = false }
+byteorder = { version = "1", default-features = false }
+serde = { version = "1", default-features = false }
+serde_derive = { version = "1", default-features = false }
+failure = { version = "0.1", default-features = false, features = ["derive"] }
+merlin = { version = "1.2", default-features = false }
 clear_on_drop = "0.2"
 
 [dev-dependencies]
@@ -31,8 +33,11 @@ bincode = "1"
 rand_chacha = "0.1"
 
 [features]
+default = ["std", "avx2_backend"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
+std = ["serde/std"]
+alloc = ["rand_core/alloc", "serde/alloc"]
 
 [[test]]
 name = "range_proof"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ rand_chacha = "0.1"
 default = ["std", "avx2_backend"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
-std = ["rand/std", "serde/std", "curve25519-dalek/std", "merlin/std"]
-alloc = ["rand_core/alloc", "serde/alloc", "curve25519-dalek/alloc", "merlin/alloc"]
+std = ["rand/std", "serde/std", "merlin/std", "curve25519-dalek/std"]
+alloc = ["rand_core/alloc", "serde/alloc", "curve25519-dalek/alloc"]
 
 [[test]]
 name = "range_proof"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
 cfg-if = "0.1"
-curve25519-dalek = { version = "1.2", default-features = false, features = ["u64_backend", "nightly", "serde"] }
+curve25519-dalek = { version = "1", default-features = false, features = ["u64_backend", "nightly", "serde"] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 digest = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
 cfg-if = "0.1"
-curve25519-dalek = { version = "1", default-features = false, features = ["u64_backend", "nightly", "serde"] }
+curve25519-dalek = { version = "1.2", default-features = false, features = ["u64_backend", "nightly", "serde"] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 digest = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ rand_chacha = "0.1"
 default = ["std", "avx2_backend"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
-std = ["serde/std"]
-alloc = ["rand_core/alloc", "serde/alloc"]
+std = ["serde/std", "curve25519-dalek/std"]
+alloc = ["rand_core/alloc", "serde/alloc", "curve25519-dalek/alloc"]
 
 [[test]]
 name = "range_proof"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["cryptography", "crypto", "ristretto", "zero-knowledge", "bulletproo
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
-cfg-if = "0.1"
 curve25519-dalek = { version = "1.2", default-features = false, features = ["u64_backend", "nightly", "serde"] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["cryptography", "crypto", "ristretto", "zero-knowledge", "bulletproo
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
-curve25519-dalek = { version = "1.2", default-features = false, features = ["u64_backend", "nightly", "serde"] }
+curve25519-dalek = { version = "1.2", default-features = false, features = ["u64_backend", "nightly", "serde", "alloc"] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 digest = { version = "0.8", default-features = false }
-rand_core = { version = "0.4", default-features = false }
+rand_core = { version = "0.4", default-features = false, features = ["alloc"] }
 rand = { version = "0.6", default-features = false }
 byteorder = { version = "1", default-features = false }
-serde = { version = "1", default-features = false }
+serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1", default-features = false }
 failure = { version = "0.1", default-features = false, features = ["derive"] }
 merlin = { version = "1.2", default-features = false }
@@ -35,8 +35,7 @@ rand_chacha = "0.1"
 default = ["std", "avx2_backend"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
-std = ["rand/std", "serde/std", "merlin/std", "curve25519-dalek/std"]
-alloc = ["rand_core/alloc", "serde/alloc", "curve25519-dalek/alloc"]
+std = ["rand/std"]
 
 [[test]]
 name = "range_proof"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ rand_chacha = "0.1"
 default = ["std", "avx2_backend"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
-std = ["serde/std", "curve25519-dalek/std"]
-alloc = ["rand_core/alloc", "serde/alloc", "curve25519-dalek/alloc"]
+std = ["serde/std", "curve25519-dalek/std", "merlin/std"]
+alloc = ["rand_core/alloc", "serde/alloc", "curve25519-dalek/alloc", "merlin/alloc"]
 
 [[test]]
 name = "range_proof"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,7 @@ rand_chacha = "0.1"
 
 [features]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
-# Disable the yoloproofs feature in the released crate.
-# To test it, use a git dependency on the develop branch and enable the
-# yoloproofs feature.  Note that this means it's impossible to publish a crate
-# depending on the unstable R1CS API.
-#yoloproofs = []
+yoloproofs = []
 
 [[test]]
 name = "range_proof"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,12 @@
 //! Errors related to proving and verifying proofs.
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+        use alloc::vec::Vec;
+    }
+}
+
 /// Represents an error in proof creation, verification, or parsing.
 #[derive(Fail, Clone, Debug, Eq, PartialEq)]
 pub enum ProofError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,11 +1,9 @@
 //! Errors related to proving and verifying proofs.
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-        use alloc::vec::Vec;
-    }
-}
+#[cfg(feature = "alloc")]        
+extern crate alloc;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 /// Represents an error in proof creation, verification, or parsing.
 #[derive(Fail, Clone, Debug, Eq, PartialEq)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,6 @@
 //! Errors related to proving and verifying proofs.
 
-#[cfg(feature = "alloc")]        
 extern crate alloc;
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 /// Represents an error in proof creation, verification, or parsing.

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -4,6 +4,13 @@
 #![allow(non_snake_case)]
 #![deny(missing_docs)]
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+        use alloc::vec::Vec;
+    }
+}
+
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::RistrettoPoint;

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -4,12 +4,11 @@
 #![allow(non_snake_case)]
 #![deny(missing_docs)]
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-        use alloc::vec::Vec;
-    }
-}
+#[cfg(feature = "alloc")]        
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -4,18 +4,14 @@
 #![allow(non_snake_case)]
 #![deny(missing_docs)]
 
-#[cfg(feature = "alloc")]        
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
-
 use digest::{ExtendableOutput, Input, XofReader};
 use sha3::{Sha3XofReader, Sha3_512, Shake256};
 

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -4,6 +4,13 @@
 use std::borrow::Borrow;
 use std::iter;
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+        use alloc::vec::Vec;
+    }
+}
+
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::VartimeMultiscalarMul;

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -1,13 +1,19 @@
 #![allow(non_snake_case)]
 #![doc(include = "../docs/inner-product-protocol.md")]
 
-use std::borrow::Borrow;
-use std::iter;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        use std::borrow::Borrow;
+        use std::iter;
+    }
+}
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "alloc")] {
         extern crate alloc;
         use alloc::vec::Vec;
+        use alloc::iter;
+        use alloc::borrow::Borrow;
     }
 }
 

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -3,8 +3,8 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
 use alloc::borrow::Borrow;
+use alloc::vec::Vec;
 
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -4,7 +4,6 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         use std::borrow::Borrow;
-        use std::iter;
     }
 }
 
@@ -12,11 +11,11 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "alloc")] {
         extern crate alloc;
         use alloc::vec::Vec;
-        use alloc::iter;
         use alloc::borrow::Borrow;
     }
 }
 
+use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::VartimeMultiscalarMul;

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -1,15 +1,10 @@
 #![allow(non_snake_case)]
 #![doc(include = "../docs/inner-product-protocol.md")]
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-#[cfg(feature = "alloc")]
 use alloc::borrow::Borrow;
-#[cfg(feature = "std")]
-use std::borrow::Borrow;
 
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -1,19 +1,15 @@
 #![allow(non_snake_case)]
 #![doc(include = "../docs/inner-product-protocol.md")]
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        use std::borrow::Borrow;
-    }
-}
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-        use alloc::vec::Vec;
-        use alloc::borrow::Borrow;
-    }
-}
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "alloc")]
+use alloc::borrow::Borrow;
+#[cfg(feature = "std")]
+use std::borrow::Borrow;
 
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "alloc", feature(alloc))]
 #![feature(nll)]
 #![feature(external_doc)]
 #![feature(try_trait)]
@@ -9,7 +8,6 @@
 
 extern crate byteorder;
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "std")]
@@ -53,9 +51,6 @@ mod generators;
 mod inner_product_proof;
 mod range_proof;
 mod transcript;
-
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 
 pub use errors::ProofError;
 pub use generators::{BulletproofGens, BulletproofGensShare, PedersenGens};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate byteorder;
 extern crate core;
 extern crate digest;
-extern crate rand;
+extern crate rand_core;
 extern crate sha3;
 
 extern crate clear_on_drop;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![feature(nll)]
 #![feature(external_doc)]
 #![feature(try_trait)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ cfg_if::cfg_if! {
 #[cfg(feature = "std")]
 extern crate core;
 
+#[cfg(feature = "std")]
+extern crate rand;
+
 extern crate digest;
 extern crate rand_core;
 extern crate sha3;
@@ -68,4 +71,8 @@ pub mod range_proof_mpc {
 }
 
 #[cfg(feature = "yoloproofs")]
-pub mod r1cs;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        pub mod r1cs;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,8 @@
 
 extern crate byteorder;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-        use alloc::vec::Vec;
-    }
-}
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 #[cfg(feature = "std")]
 extern crate core;
@@ -58,6 +54,9 @@ mod inner_product_proof;
 mod range_proof;
 mod transcript;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 pub use errors::ProofError;
 pub use generators::{BulletproofGens, BulletproofGensShare, PedersenGens};
 pub use range_proof::RangeProof;
@@ -71,8 +70,5 @@ pub mod range_proof_mpc {
 }
 
 #[cfg(feature = "yoloproofs")]
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        pub mod r1cs;
-    }
-}
+#[cfg(feature = "std")]
+pub mod r1cs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "alloc", feature(alloc))]
 #![feature(nll)]
 #![feature(external_doc)]
 #![feature(try_trait)]
@@ -7,7 +8,17 @@
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
 
 extern crate byteorder;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+        use alloc::vec::Vec;
+    }
+}
+
+#[cfg(feature = "std")]
 extern crate core;
+
 extern crate digest;
 extern crate rand_core;
 extern crate sha3;

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -14,6 +14,10 @@ cfg_if::cfg_if! {
     }
 }
 
+<<<<<<< HEAD
+=======
+use curve25519_dalek::ristretto::RistrettoPoint;
+>>>>>>> use naive curve point serialization in internal data structures
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 
@@ -105,18 +109,19 @@ impl<'a, 'b> DealerAwaitingBitCommitments<'a, 'b> {
 
         // Commit each V_j individually
         for vc in bit_commitments.iter() {
-            self.transcript.append_point(b"V", &CompressedRistretto::from_slice(&vc.V_j));
+            self.transcript.append_point(b"V", &vc.V_j);
         }
 
-        // Append aggregated A_j, S_j
-        let A: RistrettoPoint = bit_commitments.iter().map(|vc| CompressedRistretto::from_slice(&vc.A_j).decompress().unwrap()).sum();
+        // Commit aggregated A_j, S_j
+        let A: RistrettoPoint = bit_commitments.iter().map(|vc| vc.A_j).sum();
         self.transcript.append_point(b"A", &A.compress());
 
-        let S: RistrettoPoint = bit_commitments.iter().map(|vc| CompressedRistretto::from_slice(&vc.S_j).decompress().unwrap()).sum();
+        let S: RistrettoPoint = bit_commitments.iter().map(|vc| vc.S_j).sum();
         self.transcript.append_point(b"S", &S.compress());
+>>>>>>> use naive curve point serialization in internal data structures
 
-        let y = self.transcript.challenge_scalar(b"y").to_bytes();
-        let z = self.transcript.challenge_scalar(b"z").to_bytes();
+        let y = self.transcript.challenge_scalar(b"y");
+        let z = self.transcript.challenge_scalar(b"z");
         let bit_challenge = BitChallenge { y, z };
 
         Ok((
@@ -166,13 +171,13 @@ impl<'a, 'b> DealerAwaitingPolyCommitments<'a, 'b> {
         }
 
         // Commit sums of T_1_j's and T_2_j's
-        let T_1: RistrettoPoint = poly_commitments.iter().map(|pc| CompressedRistretto::from_slice(&pc.T_1_j).decompress().unwrap()).sum();
-        let T_2: RistrettoPoint = poly_commitments.iter().map(|pc| CompressedRistretto::from_slice(&pc.T_2_j).decompress().unwrap()).sum();
+        let T_1: RistrettoPoint = poly_commitments.iter().map(|pc| pc.T_1_j).sum();
+        let T_2: RistrettoPoint = poly_commitments.iter().map(|pc| pc.T_2_j).sum();
 
         self.transcript.append_point(b"T_1", &T_1.compress());
         self.transcript.append_point(b"T_2", &T_2.compress());
 
-        let x = self.transcript.challenge_scalar(b"x").to_bytes();
+        let x = self.transcript.challenge_scalar(b"x");
         let poly_challenge = PolyChallenge { x };
 
         Ok((
@@ -228,9 +233,9 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
             return Err(MPCError::WrongNumProofShares);
         }
 
-        let t_x: Scalar = proof_shares.iter().map(|ps| Scalar::from_bytes_mod_order(ps.t_x)).sum();
-        let t_x_blinding: Scalar = proof_shares.iter().map(|ps| Scalar::from_bytes_mod_order(ps.t_x_blinding)).sum();
-        let e_blinding: Scalar = proof_shares.iter().map(|ps| Scalar::from_bytes_mod_order(ps.e_blinding)).sum();
+        let t_x: Scalar = proof_shares.iter().map(|ps| ps.t_x).sum();
+        let t_x_blinding: Scalar = proof_shares.iter().map(|ps| ps.t_x_blinding).sum();
+        let e_blinding: Scalar = proof_shares.iter().map(|ps| ps.e_blinding).sum();
 
         self.transcript.append_scalar(b"t_x", &t_x);
         self.transcript
@@ -246,21 +251,13 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
             .take(self.n * self.m)
             .collect();
 
-        let l_vec_bytes: Vec<CurveScalar> = proof_shares
+        let l_vec: Vec<Scalar> = proof_shares
             .iter()
             .flat_map(|ps| ps.l_vec.clone().into_iter())
             .collect();
-        let l_vec: Vec<Scalar> = l_vec_bytes
-            .iter()
-            .map(|ps| Scalar::from_bytes_mod_order(*ps))
-            .collect();
-        let r_vec_bytes: Vec<CurveScalar> = proof_shares
+        let r_vec: Vec<Scalar> = proof_shares
             .iter()
             .flat_map(|ps| ps.r_vec.clone().into_iter())
-            .collect();
-        let r_vec: Vec<Scalar> = r_vec_bytes
-            .iter()
-            .map(|ps| Scalar::from_bytes_mod_order(*ps))
             .collect();
 
         let ipp_proof = inner_product_proof::InnerProductProof::create(
@@ -306,7 +303,7 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
     ) -> Result<RangeProof, MPCError> {
         let proof = self.assemble_shares(proof_shares)?;
 
-        let Vs: Vec<_> = self.bit_commitments.iter().map(|vc| CompressedRistretto::from_slice(&vc.V_j)).collect();
+        let Vs: Vec<_> = self.bit_commitments.iter().map(|vc| vc.V_j).collect();
 
         // See comment in `Dealer::new` for why we use `initial_transcript`
         let transcript = &mut self.initial_transcript;

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -6,12 +6,11 @@
 
 use core::iter;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-        use alloc::vec::Vec;
-    }
-}
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -5,7 +5,6 @@
 //! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
 use core::iter;
-use curve25519_dalek::ristretto::RistrettoPoint;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "alloc")] {
@@ -14,10 +13,7 @@ cfg_if::cfg_if! {
     }
 }
 
-<<<<<<< HEAD
-=======
 use curve25519_dalek::ristretto::RistrettoPoint;
->>>>>>> use naive curve point serialization in internal data structures
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -118,7 +118,6 @@ impl<'a, 'b> DealerAwaitingBitCommitments<'a, 'b> {
 
         let S: RistrettoPoint = bit_commitments.iter().map(|vc| vc.S_j).sum();
         self.transcript.append_point(b"S", &S.compress());
->>>>>>> use naive curve point serialization in internal data structures
 
         let y = self.transcript.challenge_scalar(b"y");
         let z = self.transcript.challenge_scalar(b"z");

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -4,12 +4,16 @@
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
 //! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
-<<<<<<< HEAD
 use core::iter;
 use curve25519_dalek::ristretto::RistrettoPoint;
-=======
-use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
->>>>>>> use upstream dalek curve release, without using serde; remove all naive Ristretto and Scalar serialization; convert to and from byte arrays when dealing with serialized data structures
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+        use alloc::vec::Vec;
+    }
+}
+
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -6,10 +6,8 @@
 
 use core::iter;
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 use curve25519_dalek::ristretto::RistrettoPoint;

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -308,7 +308,7 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
         // See comment in `Dealer::new` for why we use `initial_transcript`
         let transcript = &mut self.initial_transcript;
         if proof
-            .verify_multiple(self.bp_gens, self.pc_gens, transcript, &Vs, self.n, rng)
+            .verify_multiple_with_rng(self.bp_gens, self.pc_gens, transcript, &Vs, self.n, rng)
             .is_ok()
         {
             Ok(proof)

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -24,6 +24,9 @@ use rand_core::{CryptoRng, RngCore};
 
 use util;
 
+#[cfg(feature = "std")]
+use rand::thread_rng;
+
 use super::messages::*;
 
 /// Used to construct a dealer for the aggregated rangeproof MPC protocol.
@@ -293,6 +296,17 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
     /// `proof_shares`, then validate the proof to ensure that all
     /// `ProofShare`s were well-formed.
     ///
+    /// This is a convenience wrapper around receive_shares_with_rng
+    ///
+    #[cfg(feature = "std")]
+    pub fn receive_shares(self, proof_shares: &[ProofShare]) -> Result<RangeProof, MPCError> {
+        self.receive_shares_with_rng(proof_shares, &mut thread_rng())
+    }
+
+    /// Assemble the final aggregated [`RangeProof`] from the given
+    /// `proof_shares`, then validate the proof to ensure that all
+    /// `ProofShare`s were well-formed.
+    ///
     /// If the aggregated proof fails to validate, this function
     /// audits the submitted shares to determine which shares were
     /// invalid.  This information is returned as part of the
@@ -302,7 +316,7 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
     /// performing local aggregation,
     /// [`receive_trusted_shares`](DealerAwaitingProofShares::receive_trusted_shares)
     /// saves time by skipping verification of the aggregated proof.
-    pub fn receive_shares<T: RngCore + CryptoRng>(
+    pub fn receive_shares_with_rng<T: RngCore + CryptoRng>(
         mut self,
         proof_shares: &[ProofShare],
         rng: &mut T,

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -4,10 +4,8 @@
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
 //! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -18,48 +18,43 @@ use curve25519_dalek::scalar::Scalar;
 
 use generators::{BulletproofGens, PedersenGens};
 
-/// A byte array that holds a Scalar
-pub type CurvePoint = [u8; 32];
-/// A byte array that holds a CompressedRistretto
-pub type CurveScalar = [u8; 32];
-
 /// A commitment to the bits of a party's value.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct BitCommitment {
-    pub(super) V_j: CurvePoint,
-    pub(super) A_j: CurvePoint,
-    pub(super) S_j: CurvePoint,
+    pub(super) V_j: CompressedRistretto,
+    pub(super) A_j: RistrettoPoint,
+    pub(super) S_j: RistrettoPoint,
 }
 
 /// Challenge values derived from all parties' [`BitCommitment`]s.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct BitChallenge {
-    pub(super) y: CurveScalar,
-    pub(super) z: CurveScalar,
+    pub(super) y: Scalar,
+    pub(super) z: Scalar,
 }
 
 /// A commitment to a party's polynomial coefficents.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct PolyCommitment {
-    pub(super) T_1_j: CurvePoint,
-    pub(super) T_2_j: CurvePoint,
+    pub(super) T_1_j: RistrettoPoint,
+    pub(super) T_2_j: RistrettoPoint,
 }
 
 /// Challenge values derived from all parties' [`PolyCommitment`]s.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct PolyChallenge {
-    pub(super) x: CurveScalar,
+    pub(super) x: Scalar,
 }
 
 /// A party's proof share, ready for aggregation into the final
 /// [`RangeProof`](::RangeProof).
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ProofShare {
-    pub(super) t_x: CurveScalar,
-    pub(super) t_x_blinding: CurveScalar,
-    pub(super) e_blinding: CurveScalar,
-    pub(super) l_vec: Vec<CurveScalar>,
-    pub(super) r_vec: Vec<CurveScalar>,
+    pub(super) t_x: Scalar,
+    pub(super) t_x_blinding: Scalar,
+    pub(super) e_blinding: Scalar,
+    pub(super) l_vec: Vec<Scalar>,
+    pub(super) r_vec: Vec<Scalar>,
 }
 
 impl ProofShare {
@@ -81,9 +76,8 @@ impl ProofShare {
         use util;
 
         let n = self.l_vec.len();
-        let (y, z) = (&Scalar::from_bytes_mod_order(bit_challenge.y), &Scalar::from_bytes_mod_order(bit_challenge.z));
-        let x = &Scalar::from_bytes_mod_order(poly_challenge.x);
-        let e_blinding = &Scalar::from_bytes_mod_order(self.e_blinding);
+        let (y, z) = (&bit_challenge.y, &bit_challenge.z);
+        let x = &poly_challenge.x;
 
         // Precompute some variables
         let zz = z * z;
@@ -92,16 +86,14 @@ impl ProofShare {
         let y_jn = util::scalar_exp_vartime(y, (j * n) as u64); // y^(j*n)
         let y_jn_inv = y_jn.invert(); // y^(-j*n)
         let y_inv = y.invert(); // y^(-1)
-        let l_vec: Vec<Scalar> = self.l_vec.iter().map(|s| Scalar::from_bytes_mod_order(*s)).collect();
-        let r_vec: Vec<Scalar> = self.r_vec.iter().map(|s| Scalar::from_bytes_mod_order(*s)).collect();
-        let t_x: Scalar = Scalar::from_bytes_mod_order(self.t_x);
-        
-        if t_x != inner_product(&l_vec, &r_vec) {
+
+        if self.t_x != inner_product(&self.l_vec, &self.r_vec) {
             return Err(());
         }
 
-        let g = l_vec.iter().map(|l_i| minus_z - l_i);
-        let h = r_vec
+        let g = self.l_vec.iter().map(|l_i| minus_z - l_i);
+        let h = self
+            .r_vec
             .iter()
             .zip(util::exp_iter(Scalar::from(2u64)))
             .zip(util::exp_iter(y_inv))
@@ -112,11 +104,11 @@ impl ProofShare {
         let P_check = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(Scalar::one())
                 .chain(iter::once(*x))
-                .chain(iter::once(-e_blinding))
+                .chain(iter::once(-self.e_blinding))
                 .chain(g)
                 .chain(h),
-            iter::once(&CompressedRistretto::from_slice(&bit_commitment.A_j).decompress().unwrap())
-                .chain(iter::once(&CompressedRistretto::from_slice(&bit_commitment.S_j).decompress().unwrap()))
+            iter::once(&bit_commitment.A_j)
+                .chain(iter::once(&bit_commitment.S_j))
                 .chain(iter::once(&pc_gens.B_blinding))
                 .chain(bp_gens.share(j).G(n))
                 .chain(bp_gens.share(j).H(n)),
@@ -125,23 +117,20 @@ impl ProofShare {
             return Err(());
         }
 
-        let V_j = CompressedRistretto::from_slice(&bit_commitment.V_j).decompress().ok_or(())?;
+        let V_j = bit_commitment.V_j.decompress().ok_or(())?;
 
         let sum_of_powers_y = util::sum_of_powers(&y, n);
         let sum_of_powers_2 = util::sum_of_powers(&Scalar::from(2u64), n);
         let delta = (z - zz) * sum_of_powers_y * y_jn - z * zz * sum_of_powers_2 * z_j;
-        let t_x_blinding: Scalar = Scalar::from_bytes_mod_order(self.t_x_blinding);
-        let T_1_j = CompressedRistretto::from_slice(&poly_commitment.T_1_j).decompress().ok_or(())?;
-        let T_2_j = CompressedRistretto::from_slice(&poly_commitment.T_2_j).decompress().ok_or(())?;
         let t_check = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(zz * z_j)
                 .chain(iter::once(*x))
                 .chain(iter::once(x * x))
-                .chain(iter::once(delta - t_x))
-                .chain(iter::once(-t_x_blinding)),
+                .chain(iter::once(delta - self.t_x))
+                .chain(iter::once(-self.t_x_blinding)),
             iter::once(&V_j)
-                .chain(iter::once(&T_1_j))
-                .chain(iter::once(&T_2_j))
+                .chain(iter::once(&poly_commitment.T_1_j))
+                .chain(iter::once(&poly_commitment.T_2_j))
                 .chain(iter::once(&pc_gens.B))
                 .chain(iter::once(&pc_gens.B_blinding)),
         );

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -11,6 +11,8 @@ cfg_if::cfg_if! {
     }
 }
 
+use core::iter;
+
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 
@@ -73,8 +75,6 @@ impl ProofShare {
         poly_commitment: &PolyCommitment,
         poly_challenge: &PolyChallenge,
     ) -> Result<(), ()> {
-        use std::iter;
-
         use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
 
         use inner_product_proof::inner_product;

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -4,18 +4,14 @@
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
 //! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-        use alloc::vec::Vec;
-    }
-}
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 use core::iter;
-
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-
 use generators::{BulletproofGens, PedersenGens};
 
 /// A commitment to the bits of a party's value.

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -4,6 +4,13 @@
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
 //! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+        use alloc::vec::Vec;
+    }
+}
+
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -606,7 +606,7 @@ mod tests {
         // data is shared between the prover and the verifier.
 
         // Use bincode for serialization
-        use bincode;
+        //use bincode; // already present in lib.rs
 
         // Both prover and verifier have access to the generators and the proof
         let max_bitsize = 64;
@@ -616,7 +616,7 @@ mod tests {
 
         // Prover's scope
         let (proof_bytes, value_commitments) = {
-            use rand::Rng;
+            use self::rand::Rng;
             let mut rng = rand::thread_rng();
 
             // 0. Create witness data
@@ -691,7 +691,9 @@ mod tests {
 
     #[test]
     fn create_and_verify_n_64_m_8() {
-        singleparty_create_and_verify_helper(64, 8);
+        // XXX disable this test since it's failing with
+        //     'attempt to negate with overflow'
+        //singleparty_create_and_verify_helper(64, 8);
     }
 
     #[test]
@@ -708,7 +710,7 @@ mod tests {
         let pc_gens = PedersenGens::default();
         let bp_gens = BulletproofGens::new(n, m);
 
-        use rand::Rng;
+        use self::rand::Rng;
         let mut rng = rand::thread_rng();
         let mut transcript = Transcript::new(b"AggregatedRangeProofTest");
 
@@ -732,19 +734,19 @@ mod tests {
 
         let dealer = Dealer::new(&bp_gens, &pc_gens, &mut transcript, n, m).unwrap();
 
-        let (party0, bit_com0) = party0.assign_position(0).unwrap();
-        let (party1, bit_com1) = party1.assign_position(1).unwrap();
-        let (party2, bit_com2) = party2.assign_position(2).unwrap();
-        let (party3, bit_com3) = party3.assign_position(3).unwrap();
+        let (party0, bit_com0) = party0.assign_position(0, &mut rng).unwrap();
+        let (party1, bit_com1) = party1.assign_position(1, &mut rng).unwrap();
+        let (party2, bit_com2) = party2.assign_position(2, &mut rng).unwrap();
+        let (party3, bit_com3) = party3.assign_position(3, &mut rng).unwrap();
 
         let (dealer, bit_challenge) = dealer
             .receive_bit_commitments(vec![bit_com0, bit_com1, bit_com2, bit_com3])
             .unwrap();
 
-        let (party0, poly_com0) = party0.apply_challenge(&bit_challenge);
-        let (party1, poly_com1) = party1.apply_challenge(&bit_challenge);
-        let (party2, poly_com2) = party2.apply_challenge(&bit_challenge);
-        let (party3, poly_com3) = party3.apply_challenge(&bit_challenge);
+        let (party0, poly_com0) = party0.apply_challenge(&bit_challenge, &mut rng);
+        let (party1, poly_com1) = party1.apply_challenge(&bit_challenge, &mut rng);
+        let (party2, poly_com2) = party2.apply_challenge(&bit_challenge, &mut rng);
+        let (party3, poly_com3) = party3.apply_challenge(&bit_challenge, &mut rng);
 
         let (dealer, poly_challenge) = dealer
             .receive_poly_commitments(vec![poly_com0, poly_com1, poly_com2, poly_com3])
@@ -755,7 +757,7 @@ mod tests {
         let share2 = party2.apply_challenge(&poly_challenge).unwrap();
         let share3 = party3.apply_challenge(&poly_challenge).unwrap();
 
-        match dealer.receive_shares(&[share0, share1, share2, share3]) {
+        match dealer.receive_shares(&[share0, share1, share2, share3], &mut rng) {
             Err(MPCError::MalformedProofShares { bad_shares }) => {
                 assert_eq!(bad_shares, vec![1, 3]);
             }
@@ -781,7 +783,7 @@ mod tests {
         let pc_gens = PedersenGens::default();
         let bp_gens = BulletproofGens::new(n, m);
 
-        use rand::Rng;
+        use self::rand::Rng;
         let mut rng = rand::thread_rng();
         let mut transcript = Transcript::new(b"AggregatedRangeProofTest");
 
@@ -793,11 +795,11 @@ mod tests {
 
         // Now do the protocol flow as normal....
 
-        let (party0, bit_com0) = party0.assign_position(0).unwrap();
+        let (party0, bit_com0) = party0.assign_position(0, &mut rng).unwrap();
 
         let (dealer, bit_challenge) = dealer.receive_bit_commitments(vec![bit_com0]).unwrap();
 
-        let (party0, poly_com0) = party0.apply_challenge(&bit_challenge);
+        let (party0, poly_com0) = party0.apply_challenge(&bit_challenge, &mut rng);
 
         let (_dealer, mut poly_challenge) =
             dealer.receive_poly_commitments(vec![poly_com0]).unwrap();

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -29,7 +29,7 @@ use transcript::TranscriptProtocol;
 use util;
 
 use rand_core::{CryptoRng, RngCore};
-use serde::de::Visitor;	
+use serde::de::Visitor;
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 
 // Modules for MPC protocol
@@ -147,8 +147,15 @@ impl RangeProof {
         n: usize,
         rng: &mut T,
     ) -> Result<(RangeProof, CompressedRistretto), ProofError> {
-        let (p, Vs) =
-            RangeProof::prove_multiple_with_rng(bp_gens, pc_gens, transcript, &[v], &[*v_blinding], n, rng)?;
+        let (p, Vs) = RangeProof::prove_multiple_with_rng(
+            bp_gens,
+            pc_gens,
+            transcript,
+            &[v],
+            &[*v_blinding],
+            n,
+            rng,
+        )?;
         Ok((p, Vs[0]))
     }
 
@@ -165,7 +172,15 @@ impl RangeProof {
         v_blinding: &Scalar,
         n: usize,
     ) -> Result<(RangeProof, CompressedRistretto), ProofError> {
-        RangeProof::prove_single_with_rng(bp_gens, pc_gens, transcript, v, v_blinding, n, &mut thread_rng())
+        RangeProof::prove_single_with_rng(
+            bp_gens,
+            pc_gens,
+            transcript,
+            v,
+            v_blinding,
+            n,
+            &mut thread_rng(),
+        )
     }
 
     /// Create a rangeproof for a set of values.
@@ -290,9 +305,17 @@ impl RangeProof {
         blindings: &[Scalar],
         n: usize,
     ) -> Result<(RangeProof, Vec<CompressedRistretto>), ProofError> {
-        RangeProof::prove_multiple_with_rng(bp_gens, pc_gens, transcript, values, blindings, n, &mut thread_rng())
+        RangeProof::prove_multiple_with_rng(
+            bp_gens,
+            pc_gens,
+            transcript,
+            values,
+            blindings,
+            n,
+            &mut thread_rng(),
+        )
     }
-    
+
     /// Verifies a rangeproof for a given value commitment \\(V\\).
     ///
     /// This is a convenience wrapper around `verify_multiple` for the `m=1` case.
@@ -323,7 +346,7 @@ impl RangeProof {
     ) -> Result<(), ProofError> {
         self.verify_single_with_rng(bp_gens, pc_gens, transcript, V, n, &mut thread_rng())
     }
-    
+
     /// Verifies an aggregated rangeproof for the given value commitments.
     pub fn verify_multiple_with_rng<T: RngCore + CryptoRng>(
         &self,
@@ -446,10 +469,16 @@ impl RangeProof {
         value_commitments: &[CompressedRistretto],
         n: usize,
     ) -> Result<(), ProofError> {
-        self.verify_multiple_with_rng(bp_gens, pc_gens, transcript, value_commitments, n, &mut thread_rng())
+        self.verify_multiple_with_rng(
+            bp_gens,
+            pc_gens,
+            transcript,
+            value_commitments,
+            n,
+            &mut thread_rng(),
+        )
     }
 
-    
     /// Serializes the proof into a byte array of \\(2 \lg n + 9\\)
     /// 32-byte elements, where \\(n\\) is the number of secret bits.
     ///

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -22,6 +22,8 @@ use transcript::TranscriptProtocol;
 use util;
 
 use rand_core::{CryptoRng, RngCore};
+use serde::de::Visitor;	
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 
 // Modules for MPC protocol
 
@@ -443,7 +445,7 @@ impl RangeProof {
         })
     }
 }
-/*
+
 impl Serialize for RangeProof {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -478,7 +480,7 @@ impl<'de> Deserialize<'de> for RangeProof {
         deserializer.deserialize_bytes(RangeProofVisitor)
     }
 }
-*/
+
 /// Compute
 /// \\[
 /// \delta(y,z) = (z - z^{2}) \langle \mathbf{1}, {\mathbf{y}}^{n \cdot m} \rangle - \sum_{j=0}^{m-1} z^{j+3} \cdot \langle \mathbf{1}, {\mathbf{2}}^{n \cdot m} \rangle

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -316,7 +316,7 @@ impl RangeProof {
         let w = transcript.challenge_scalar(b"w");
 
         // Challenge value for batching statements to be verified
-        let c = Scalar::random(&mut rng);
+        let c = Scalar::random(rng);
 
         let (x_sq, x_inv_sq, s) = self.ipp_proof.verification_scalars(n * m, transcript)?;
         let s_inv = s.iter().rev();

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -246,7 +246,7 @@ impl RangeProof {
 
         let proof = dealer.receive_trusted_shares(&proof_shares)?;
 
-        Ok((proof, value_commitments))
+        Ok((proof, value_commitments.iter().map(|s| CompressedRistretto::from_slice(s)).collect()))
     }
 
     /// Verifies a rangeproof for a given value commitment \\(V\\).

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -8,7 +8,7 @@ cfg_if::cfg_if! {
     }
 }
 
-use std::iter;
+use core::iter;
 
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -439,7 +439,7 @@ impl RangeProof {
         })
     }
 }
-
+/*
 impl Serialize for RangeProof {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -474,7 +474,7 @@ impl<'de> Deserialize<'de> for RangeProof {
         deserializer.deserialize_bytes(RangeProofVisitor)
     }
 }
-
+*/
 /// Compute
 /// \\[
 /// \delta(y,z) = (z - z^{2}) \langle \mathbf{1}, {\mathbf{y}}^{n \cdot m} \rangle - \sum_{j=0}^{m-1} z^{j+3} \cdot \langle \mathbf{1}, {\mathbf{2}}^{n \cdot m} \rangle

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -14,9 +14,6 @@ use inner_product_proof::InnerProductProof;
 use transcript::TranscriptProtocol;
 use util;
 
-use serde::de::Visitor;
-use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
-
 use rand_core::{CryptoRng, RngCore};
 
 // Modules for MPC protocol
@@ -66,88 +63,6 @@ pub struct RangeProof {
     e_blinding: Scalar,
     /// Proof data for the inner-product argument.
     ipp_proof: InnerProductProof,
-}
-
-/// In order to get around weird serde nostd issues with curve255519-dalek,
-/// our custom bulletproofs fork no longer does any curve serde ops.  Some
-/// of the internal bulletproofs data structures were changed to use byte buffers
-/// which were converted as needed.  But the main RangeProof data structure
-/// was left alone, it just had the De/Serialize derivations removed.  So we need a parallel
-/// data structure here that does support naive serialization.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SerializedInnerProductProof {
-    pub L_vec: Vec<[u8; 32]>,
-    pub R_vec: Vec<[u8; 32]>,
-    pub a: [u8; 32],
-    pub b: [u8; 32],
-}
-
-impl SerializedInnerProductProof {
-    pub fn from(proof: &InnerProductProof) -> SerializedInnerProductProof {
-        SerializedInnerProductProof {
-            L_vec: proof.L_vec.iter().map(|cr| cr.to_bytes()).collect(),
-            R_vec: proof.R_vec.iter().map(|cr| cr.to_bytes()).collect(),
-            a: proof.a.to_bytes(),
-            b: proof.b.to_bytes(),
-        }
-    }
-
-    pub fn to_inner_product_proof(self) -> InnerProductProof {
-        InnerProductProof {
-            L_vec: self.L_vec.iter().map(|b| CompressedRistretto::from_slice(b)).collect(),
-            R_vec: self.R_vec.iter().map(|b| CompressedRistretto::from_slice(b)).collect(),
-            a: Scalar::from_bytes_mod_order(self.a),
-            b: Scalar::from_bytes_mod_order(self.b),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SerializedRangeProof {
-    /// Commitment to the bits of the value
-    A: [u8; 32],
-    /// Commitment to the blinding factors
-    S: [u8; 32],
-    /// Commitment to the \\(t_1\\) coefficient of \\( t(x) \\)
-    T_1: [u8; 32],
-    /// Commitment to the \\(t_2\\) coefficient of \\( t(x) \\)
-    T_2: [u8; 32],
-    /// Evaluation of the polynomial \\(t(x)\\) at the challenge point \\(x\\)
-    t_x: [u8; 32],
-    /// Blinding factor for the synthetic commitment to \\(t(x)\\)
-    t_x_blinding: [u8; 32],
-    /// Blinding factor for the synthetic commitment to the inner-product arguments
-    e_blinding: [u8; 32],
-    /// Proof data for the inner-product argument.
-    ipp_proof: SerializedInnerProductProof,
-}
-
-impl SerializedRangeProof {
-    pub fn from(proof: &RangeProof) -> SerializedRangeProof {
-        SerializedRangeProof {
-            A: proof.A.to_bytes(),
-            S: proof.S.to_bytes(),
-            T_1: proof.T_1.to_bytes(),
-            T_2: proof.T_2.to_bytes(),
-            t_x: proof.t_x.to_bytes(),
-            t_x_blinding: proof.t_x_blinding.to_bytes(),
-            e_blinding: proof.e_blinding.to_bytes(),
-            ipp_proof: SerializedInnerProductProof::from(&proof.ipp_proof),
-        }
-    }
-
-    pub fn to_range_proof(self) -> RangeProof {
-        RangeProof {
-            A: CompressedRistretto::from_slice(&self.A),
-            S: CompressedRistretto::from_slice(&self.S),
-            T_1: CompressedRistretto::from_slice(&self.T_1),
-            T_2: CompressedRistretto::from_slice(&self.T_2),
-            t_x: Scalar::from_bytes_mod_order(self.t_x),
-            t_x_blinding: Scalar::from_bytes_mod_order(self.t_x_blinding),
-            e_blinding: Scalar::from_bytes_mod_order(self.e_blinding),
-            ipp_proof: self.ipp_proof.to_inner_product_proof(),
-        }
-    }
 }
 
 impl RangeProof {

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -755,19 +755,19 @@ mod tests {
 
         let dealer = Dealer::new(&bp_gens, &pc_gens, &mut transcript, n, m).unwrap();
 
-        let (party0, bit_com0) = party0.assign_position_with_rng(0, &mut rng).unwrap();
-        let (party1, bit_com1) = party1.assign_position_with_rng(1, &mut rng).unwrap();
-        let (party2, bit_com2) = party2.assign_position_with_rng(2, &mut rng).unwrap();
-        let (party3, bit_com3) = party3.assign_position_with_rng(3, &mut rng).unwrap();
+        let (party0, bit_com0) = party0.assign_position(0).unwrap();
+        let (party1, bit_com1) = party1.assign_position(1).unwrap();
+        let (party2, bit_com2) = party2.assign_position(2).unwrap();
+        let (party3, bit_com3) = party3.assign_position(3).unwrap();
 
         let (dealer, bit_challenge) = dealer
             .receive_bit_commitments(vec![bit_com0, bit_com1, bit_com2, bit_com3])
             .unwrap();
 
-        let (party0, poly_com0) = party0.apply_challenge_with_rng(&bit_challenge, &mut rng);
-        let (party1, poly_com1) = party1.apply_challenge_with_rng(&bit_challenge, &mut rng);
-        let (party2, poly_com2) = party2.apply_challenge_with_rng(&bit_challenge, &mut rng);
-        let (party3, poly_com3) = party3.apply_challenge_with_rng(&bit_challenge, &mut rng);
+        let (party0, poly_com0) = party0.apply_challenge(&bit_challenge);
+        let (party1, poly_com1) = party1.apply_challenge(&bit_challenge);
+        let (party2, poly_com2) = party2.apply_challenge(&bit_challenge);
+        let (party3, poly_com3) = party3.apply_challenge(&bit_challenge);
 
         let (dealer, poly_challenge) = dealer
             .receive_poly_commitments(vec![poly_com0, poly_com1, poly_com2, poly_com3])
@@ -778,7 +778,7 @@ mod tests {
         let share2 = party2.apply_challenge(&poly_challenge).unwrap();
         let share3 = party3.apply_challenge(&poly_challenge).unwrap();
 
-        match dealer.receive_shares_with_rng(&[share0, share1, share2, share3], &mut rng) {
+        match dealer.receive_shares(&[share0, share1, share2, share3]) {
             Err(MPCError::MalformedProofShares { bad_shares }) => {
                 assert_eq!(bad_shares, vec![1, 3]);
             }
@@ -816,11 +816,11 @@ mod tests {
 
         // Now do the protocol flow as normal....
 
-        let (party0, bit_com0) = party0.assign_position_with_rng(0, &mut rng).unwrap();
+        let (party0, bit_com0) = party0.assign_position(0).unwrap();
 
         let (dealer, bit_challenge) = dealer.receive_bit_commitments(vec![bit_com0]).unwrap();
 
-        let (party0, poly_com0) = party0.apply_challenge_with_rng(&bit_challenge, &mut rng);
+        let (party0, poly_com0) = party0.apply_challenge(&bit_challenge);
 
         let (_dealer, mut poly_challenge) =
             dealer.receive_poly_commitments(vec![poly_com0]).unwrap();

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -11,7 +11,6 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         extern crate rand;
-        use self::rand::rngs::ThreadRng;
         use self::rand::thread_rng;
     }
 }
@@ -155,7 +154,8 @@ impl RangeProof {
 
     /// Create a rangeproof for a given pair of value `v` and
     /// blinding scalar `v_blinding`.
-    /// This is a convenience wrapper around [`RangeProof::prove_single_with_rng`].
+    /// This is a convenience wrapper around [`RangeProof::prove_single_with_rng`],
+    /// passing in a threadsafe RNG.
     #[cfg(feature = "std")]
     pub fn prove_single(
         bp_gens: &BulletproofGens,
@@ -165,8 +165,7 @@ impl RangeProof {
         v_blinding: &Scalar,
         n: usize,
     ) -> Result<(RangeProof, CompressedRistretto), ProofError> {
-        let mut rng: ThreadRng = thread_rng();
-        RangeProof::prove_single_with_rng(bp_gens, pc_gens, transcript, v, v_blinding, n, &mut rng)
+        RangeProof::prove_single_with_rng(bp_gens, pc_gens, transcript, v, v_blinding, n, &mut thread_rng())
     }
 
     /// Create a rangeproof for a set of values.
@@ -279,7 +278,9 @@ impl RangeProof {
         Ok((proof, value_commitments))
     }
 
-    /// Create a rangeproof for a set of values, passing in a threadsafe RNG (std mode only)
+    /// Create a rangeproof for a set of values.
+    /// This is a convenience wrapper around [`RangeProof::prove_multiple_with_rng`],
+    /// passing in a threadsafe RNG.
     #[cfg(feature = "std")]
     pub fn prove_multiple(
         bp_gens: &BulletproofGens,
@@ -309,7 +310,8 @@ impl RangeProof {
 
     /// Verifies a rangeproof for a given value commitment \\(V\\).
     ///
-    /// This is a convenience wrapper around `verify_multiple` for the `m=1` case.
+    /// This is a convenience wrapper around [`RangeProof::verify_single_with_rng`],
+    /// passing in a threadsafe RNG.
     #[cfg(feature = "std")]
     pub fn verify_single(
         &self,
@@ -433,6 +435,8 @@ impl RangeProof {
     }
 
     /// Verifies an aggregated rangeproof for the given value commitments.
+    /// This is a convenience wrapper around [`RangeProof::verify_multiple_with_rng`],
+    /// passing in a threadsafe RNG.
     #[cfg(feature = "std")]
     pub fn verify_multiple(
         &self,

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -5,9 +5,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate rand;
 
-use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use self::rand::thread_rng;
+use alloc::vec::Vec;
 
 use core::iter;
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -1,19 +1,15 @@
 #![allow(non_snake_case)]
 #![doc(include = "../../docs/range-proof-protocol.md")]
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-        use alloc::vec::Vec;
-    }
-}
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate rand;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        extern crate rand;
-        use self::rand::thread_rng;
-    }
-}
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use self::rand::thread_rng;
 
 use core::iter;
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -714,9 +714,7 @@ mod tests {
 
     #[test]
     fn create_and_verify_n_64_m_8() {
-        // XXX disable this test since it's failing with
-        //     'attempt to negate with overflow'
-        //singleparty_create_and_verify_helper(64, 8);
+        singleparty_create_and_verify_helper(64, 8);
     }
 
     #[test]

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -252,7 +252,7 @@ impl RangeProof {
 
         let proof = dealer.receive_trusted_shares(&proof_shares)?;
 
-        Ok((proof, value_commitments.iter().map(|s| CompressedRistretto::from_slice(s)).collect()))
+        Ok((proof, value_commitments))
     }
 
     /// Verifies a rangeproof for a given value commitment \\(V\\).

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -1,12 +1,10 @@
 #![allow(non_snake_case)]
 #![doc(include = "../../docs/range-proof-protocol.md")]
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate rand;
 
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use self::rand::thread_rng;

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -260,7 +260,7 @@ impl RangeProof {
             .into_iter()
             .enumerate()
             .map(|(j, p)| {
-                p.assign_position(j, rng)
+                p.assign_position_with_rng(j, rng)
                     .expect("We already checked the parameters, so this should never happen")
             })
             .unzip();
@@ -271,7 +271,7 @@ impl RangeProof {
 
         let (parties, poly_commitments): (Vec<_>, Vec<_>) = parties
             .into_iter()
-            .map(|p| p.apply_challenge(&bit_challenge, rng))
+            .map(|p| p.apply_challenge_with_rng(&bit_challenge, rng))
             .unzip();
 
         let (dealer, poly_challenge) = dealer.receive_poly_commitments(poly_commitments)?;
@@ -757,19 +757,19 @@ mod tests {
 
         let dealer = Dealer::new(&bp_gens, &pc_gens, &mut transcript, n, m).unwrap();
 
-        let (party0, bit_com0) = party0.assign_position(0, &mut rng).unwrap();
-        let (party1, bit_com1) = party1.assign_position(1, &mut rng).unwrap();
-        let (party2, bit_com2) = party2.assign_position(2, &mut rng).unwrap();
-        let (party3, bit_com3) = party3.assign_position(3, &mut rng).unwrap();
+        let (party0, bit_com0) = party0.assign_position_with_rng(0, &mut rng).unwrap();
+        let (party1, bit_com1) = party1.assign_position_with_rng(1, &mut rng).unwrap();
+        let (party2, bit_com2) = party2.assign_position_with_rng(2, &mut rng).unwrap();
+        let (party3, bit_com3) = party3.assign_position_with_rng(3, &mut rng).unwrap();
 
         let (dealer, bit_challenge) = dealer
             .receive_bit_commitments(vec![bit_com0, bit_com1, bit_com2, bit_com3])
             .unwrap();
 
-        let (party0, poly_com0) = party0.apply_challenge(&bit_challenge, &mut rng);
-        let (party1, poly_com1) = party1.apply_challenge(&bit_challenge, &mut rng);
-        let (party2, poly_com2) = party2.apply_challenge(&bit_challenge, &mut rng);
-        let (party3, poly_com3) = party3.apply_challenge(&bit_challenge, &mut rng);
+        let (party0, poly_com0) = party0.apply_challenge_with_rng(&bit_challenge, &mut rng);
+        let (party1, poly_com1) = party1.apply_challenge_with_rng(&bit_challenge, &mut rng);
+        let (party2, poly_com2) = party2.apply_challenge_with_rng(&bit_challenge, &mut rng);
+        let (party3, poly_com3) = party3.apply_challenge_with_rng(&bit_challenge, &mut rng);
 
         let (dealer, poly_challenge) = dealer
             .receive_poly_commitments(vec![poly_com0, poly_com1, poly_com2, poly_com3])
@@ -780,7 +780,7 @@ mod tests {
         let share2 = party2.apply_challenge(&poly_challenge).unwrap();
         let share3 = party3.apply_challenge(&poly_challenge).unwrap();
 
-        match dealer.receive_shares(&[share0, share1, share2, share3], &mut rng) {
+        match dealer.receive_shares_with_rng(&[share0, share1, share2, share3], &mut rng) {
             Err(MPCError::MalformedProofShares { bad_shares }) => {
                 assert_eq!(bad_shares, vec![1, 3]);
             }
@@ -818,11 +818,11 @@ mod tests {
 
         // Now do the protocol flow as normal....
 
-        let (party0, bit_com0) = party0.assign_position(0, &mut rng).unwrap();
+        let (party0, bit_com0) = party0.assign_position_with_rng(0, &mut rng).unwrap();
 
         let (dealer, bit_challenge) = dealer.receive_bit_commitments(vec![bit_com0]).unwrap();
 
-        let (party0, poly_com0) = party0.apply_challenge(&bit_challenge, &mut rng);
+        let (party0, poly_com0) = party0.apply_challenge_with_rng(&bit_challenge, &mut rng);
 
         let (_dealer, mut poly_challenge) =
             dealer.receive_poly_commitments(vec![poly_com0]).unwrap();

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -1,6 +1,13 @@
 #![allow(non_snake_case)]
 #![doc(include = "../../docs/range-proof-protocol.md")]
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+        use alloc::vec::Vec;
+    }
+}
+
 use std::iter;
 
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -79,7 +79,7 @@ impl<'a> PartyAwaitingPosition<'a> {
 
         let bp_share = self.bp_gens.share(j);
 
-        let a_blinding = Scalar::random(&mut rng);
+        let a_blinding = Scalar::random(rng);
         // Compute A = <a_L, G> + <a_R, H> + a_blinding * B_blinding
         let mut A = self.pc_gens.B_blinding * a_blinding;
 
@@ -95,9 +95,9 @@ impl<'a> PartyAwaitingPosition<'a> {
             i += 1;
         }
 
-        let s_blinding = Scalar::random(&mut rng);
-        let s_L: Vec<Scalar> = (0..self.n).map(|_| Scalar::random(&mut rng)).collect();
-        let s_R: Vec<Scalar> = (0..self.n).map(|_| Scalar::random(&mut rng)).collect();
+        let s_blinding = Scalar::random(rng);
+        let s_L: Vec<Scalar> = (0..self.n).map(|_| Scalar::random(rng)).collect();
+        let s_R: Vec<Scalar> = (0..self.n).map(|_| Scalar::random(rng)).collect();
 
         // Compute S = <s_L, G> + <s_R, H> + s_blinding * B_blinding
         let S = RistrettoPoint::multiscalar_mul(
@@ -185,8 +185,8 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
         let t_poly = l_poly.inner_product(&r_poly);
 
         // Generate x by committing to T_1, T_2 (line 49-54)
-        let t_1_blinding = Scalar::random(&mut rng);
-        let t_2_blinding = Scalar::random(&mut rng);
+        let t_1_blinding = Scalar::random(rng);
+        let t_2_blinding = Scalar::random(rng);
         let T_1 = self.pc_gens.commit(t_poly.1, t_1_blinding);
         let T_2 = self.pc_gens.commit(t_poly.2, t_2_blinding);
 

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -13,11 +13,11 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use clear_on_drop::clear::Clear;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
-use clear_on_drop::clear::Clear;
 use errors::MPCError;
 use generators::{BulletproofGens, PedersenGens};
 use rand_core::{CryptoRng, RngCore};

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -259,10 +259,7 @@ pub struct PartyAwaitingPolyChallenge {
 impl PartyAwaitingPolyChallenge {
     /// Receive a [`PolyChallenge`] from the dealer and compute the
     /// party's proof share.
-    pub fn apply_challenge(
-        self,
-        pc: &PolyChallenge,
-    ) -> Result<ProofShare, MPCError> {
+    pub fn apply_challenge(self, pc: &PolyChallenge) -> Result<ProofShare, MPCError> {
         // Prevent a malicious dealer from annihilating the blinding
         // factors by supplying a zero challenge.
         if pc.x == Scalar::zero() {

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -23,6 +23,9 @@ use generators::{BulletproofGens, PedersenGens};
 use rand_core::{CryptoRng, RngCore};
 use util;
 
+#[cfg(feature = "std")]
+use rand::thread_rng;
+
 use super::messages::*;
 
 /// Used to construct a party for the aggregated rangeproof MPC protocol.
@@ -70,7 +73,17 @@ pub struct PartyAwaitingPosition<'a> {
 impl<'a> PartyAwaitingPosition<'a> {
     /// Assigns a position in the aggregated proof to this party,
     /// allowing the party to commit to the bits of their value.
-    pub fn assign_position<T: RngCore + CryptoRng>(
+    #[cfg(feature = "std")]
+    pub fn assign_position(
+        self,
+        j: usize,
+    ) -> Result<(PartyAwaitingBitChallenge<'a>, BitCommitment), MPCError> {
+        self.assign_position_with_rng(j, &mut thread_rng())
+    }
+
+    /// Assigns a position in the aggregated proof to this party,
+    /// allowing the party to commit to the bits of their value.
+    pub fn assign_position_with_rng<T: RngCore + CryptoRng>(
         self,
         j: usize,
         rng: &mut T,
@@ -155,7 +168,17 @@ pub struct PartyAwaitingBitChallenge<'a> {
 impl<'a> PartyAwaitingBitChallenge<'a> {
     /// Receive a [`BitChallenge`] from the dealer and use it to
     /// compute commitments to the party's polynomial coefficients.
+    #[cfg(feature = "std")]
     pub fn apply_challenge<T: RngCore + CryptoRng>(
+        self,
+        vc: &BitChallenge,
+    ) -> (PartyAwaitingPolyChallenge, PolyCommitment) {
+        self.apply_challenge_with_rng(vc, &mut thread_rng())
+    }
+
+    /// Receive a [`BitChallenge`] from the dealer and use it to
+    /// compute commitments to the party's polynomial coefficients.
+    pub fn apply_challenge_with_rng<T: RngCore + CryptoRng>(
         self,
         vc: &BitChallenge,
         rng: &mut T,

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -116,9 +116,9 @@ impl<'a> PartyAwaitingPosition<'a> {
 
         // Return next state and all commitments
         let bit_commitment = BitCommitment {
-            V_j: self.V.to_bytes(),
-            A_j: A.compress().to_bytes(),
-            S_j: S.compress().to_bytes(),
+            V_j: self.V,
+            A_j: A,
+            S_j: S,
         };
         let next_state = PartyAwaitingBitChallenge {
             n: self.n,
@@ -166,28 +166,26 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
         rng: &mut T,
     ) -> (PartyAwaitingPolyChallenge, PolyCommitment) {
         let n = self.n;
-        let offset_y = util::scalar_exp_vartime(&Scalar::from_bytes_mod_order(vc.y), (self.j * n) as u64);
-        let offset_z = util::scalar_exp_vartime(&Scalar::from_bytes_mod_order(vc.z), self.j as u64);
+        let offset_y = util::scalar_exp_vartime(&vc.y, (self.j * n) as u64);
+        let offset_z = util::scalar_exp_vartime(&vc.z, self.j as u64);
 
         // Calculate t by calculating vectors l0, l1, r0, r1 and multiplying
         let mut l_poly = util::VecPoly1::zero(n);
         let mut r_poly = util::VecPoly1::zero(n);
 
-        let y = Scalar::from_bytes_mod_order(vc.y);
-        let z = Scalar::from_bytes_mod_order(vc.z);
-        let zz = z * z;
+        let zz = vc.z * vc.z;
         let mut exp_y = offset_y; // start at y^j
         let mut exp_2 = Scalar::one(); // start at 2^0 = 1
         for i in 0..n {
             let a_L_i = Scalar::from((self.v >> i) & 1);
             let a_R_i = a_L_i - Scalar::one();
 
-            l_poly.0[i] = a_L_i - z;
+            l_poly.0[i] = a_L_i - vc.z;
             l_poly.1[i] = self.s_L[i];
-            r_poly.0[i] = exp_y * (a_R_i + z) + zz * offset_z * exp_2;
+            r_poly.0[i] = exp_y * (a_R_i + vc.z) + zz * offset_z * exp_2;
             r_poly.1[i] = exp_y * self.s_R[i];
 
-            exp_y *= y; // y^i -> y^(i+1)
+            exp_y *= vc.y; // y^i -> y^(i+1)
             exp_2 = exp_2 + exp_2; // 2^i -> 2^(i+1)
         }
 
@@ -200,15 +198,15 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
         let T_2 = self.pc_gens.commit(t_poly.2, t_2_blinding);
 
         let poly_commitment = PolyCommitment {
-            T_1_j: T_1.compress().to_bytes(),
-            T_2_j: T_2.compress().to_bytes(),
+            T_1_j: T_1,
+            T_2_j: T_2,
         };
 
         let papc = PartyAwaitingPolyChallenge {
             v_blinding: self.v_blinding,
             a_blinding: self.a_blinding,
             s_blinding: self.s_blinding,
-            z: z,
+            z: vc.z,
             offset_z,
             l_poly,
             r_poly,
@@ -267,8 +265,7 @@ impl PartyAwaitingPolyChallenge {
     ) -> Result<ProofShare, MPCError> {
         // Prevent a malicious dealer from annihilating the blinding
         // factors by supplying a zero challenge.
-        let pc_x = Scalar::from_bytes_mod_order(pc.x);
-        if pc_x == Scalar::zero() {
+        if pc.x == Scalar::zero() {
             return Err(MPCError::MaliciousDealer);
         }
 
@@ -278,18 +275,18 @@ impl PartyAwaitingPolyChallenge {
             self.t_2_blinding,
         );
 
-        let t_x = self.t_poly.eval(pc_x);
-        let t_x_blinding = t_blinding_poly.eval(pc_x);
-        let e_blinding = self.a_blinding + self.s_blinding * &pc_x;
-        let l_vec = self.l_poly.eval(pc_x);
-        let r_vec = self.r_poly.eval(pc_x);
+        let t_x = self.t_poly.eval(pc.x);
+        let t_x_blinding = t_blinding_poly.eval(pc.x);
+        let e_blinding = self.a_blinding + self.s_blinding * &pc.x;
+        let l_vec = self.l_poly.eval(pc.x);
+        let r_vec = self.r_poly.eval(pc.x);
 
         Ok(ProofShare {
-            t_x_blinding: t_x_blinding.to_bytes(),
-            t_x: t_x.to_bytes(),
-            e_blinding: e_blinding.to_bytes(),
-            l_vec: l_vec.iter().map(|l| l.to_bytes()).collect(),
-            r_vec: r_vec.iter().map(|r| r.to_bytes()).collect(),
+            t_x_blinding,
+            t_x,
+            e_blinding,
+            l_vec,
+            r_vec,
         })
     }
 }

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -10,18 +10,15 @@
 //! modules orchestrate the protocol execution, see the documentation
 //! in the [`aggregation`](::range_proof_mpc) module.
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-        use alloc::vec::Vec;
-    }
-}
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
-
 use clear_on_drop::clear::Clear;
 use errors::MPCError;
 use generators::{BulletproofGens, PedersenGens};

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -10,10 +10,8 @@
 //! modules orchestrate the protocol execution, see the documentation
 //! in the [`aggregation`](::range_proof_mpc) module.
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -10,6 +10,13 @@
 //! modules orchestrate the protocol execution, see the documentation
 //! in the [`aggregation`](::range_proof_mpc) module.
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+        use alloc::vec::Vec;
+    }
+}
+
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -17,6 +17,7 @@ cfg_if::cfg_if! {
     }
 }
 
+use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
@@ -25,7 +26,6 @@ use clear_on_drop::clear::Clear;
 use errors::MPCError;
 use generators::{BulletproofGens, PedersenGens};
 use rand_core::{CryptoRng, RngCore};
-use std::iter;
 use util;
 
 use super::messages::*;

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -169,7 +169,7 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
     /// Receive a [`BitChallenge`] from the dealer and use it to
     /// compute commitments to the party's polynomial coefficients.
     #[cfg(feature = "std")]
-    pub fn apply_challenge<T: RngCore + CryptoRng>(
+    pub fn apply_challenge(
         self,
         vc: &BitChallenge,
     ) -> (PartyAwaitingPolyChallenge, PolyCommitment) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -71,7 +71,7 @@ pub fn exp_iter(x: Scalar) -> ScalarExp {
 pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
     if a.len() != b.len() {
         // throw some error
-        println!("lengths of vectors don't match for vector addition");
+        //println!("lengths of vectors don't match for vector addition");
     }
     let mut out = vec![Scalar::zero(); b.len()];
     for i in 0..a.len() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -73,7 +73,7 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
         // throw some error
         //println!("lengths of vectors don't match for vector addition");
     }
-    let mut out = vec![Scalar::zero(); b.len()];
+    let mut out: Vec<Scalar> = (0..b.len()).map(|_| Scalar::zero()).collect();
     for i in 0..a.len() {
         out[i] = a[i] + b[i];
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,9 @@
 #![deny(missing_docs)]
 #![allow(non_snake_case)]
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
 use alloc::vec;
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use clear_on_drop::clear::Clear;
 use curve25519_dalek::scalar::Scalar;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,13 +1,13 @@
 #![deny(missing_docs)]
 #![allow(non_snake_case)]
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-        use alloc::vec::Vec;
-    }
-}
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
+#[cfg(feature = "alloc")]
+use alloc::vec;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 use clear_on_drop::clear::Clear;
 use curve25519_dalek::scalar::Scalar;
 use inner_product_proof::inner_product;
@@ -73,7 +73,7 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
         // throw some error
         //println!("lengths of vectors don't match for vector addition");
     }
-    let mut out: Vec<Scalar> = (0..b.len()).map(|_| Scalar::zero()).collect();
+    let mut out = vec![Scalar::zero(); b.len()];
     for i in 0..a.len() {
         out[i] = a[i] + b[i];
     }
@@ -82,8 +82,7 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
 
 impl VecPoly1 {
     pub fn zero(n: usize) -> Self {
-        let zn: Vec<Scalar> = (0..n).map(|_| Scalar::zero()).collect();
-        VecPoly1(zn.clone(), zn)
+        VecPoly1(vec![Scalar::zero(); n], vec![Scalar::zero(); n])
     }
 
     pub fn inner_product(&self, rhs: &VecPoly1) -> Poly2 {
@@ -104,7 +103,7 @@ impl VecPoly1 {
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
         let n = self.0.len();
-        let mut out: Vec<Scalar> = (0..n).map(|_| Scalar::zero()).collect();
+        let mut out = vec![Scalar::zero(); n];
         for i in 0..n {
             out[i] = self.0[i] + self.1[i] * x;
         }
@@ -115,8 +114,12 @@ impl VecPoly1 {
 #[cfg(feature = "yoloproofs")]
 impl VecPoly3 {
     pub fn zero(n: usize) -> Self {
-        let zn: Vec<Scalar> = (0..n).map(|_| Scalar::zero()).collect();
-        VecPoly3(zn.clone(), zn.clone(), zn.clone(), zn.clone())
+        VecPoly3(
+            vec![Scalar::zero(); n],
+            vec![Scalar::zero(); n],
+            vec![Scalar::zero(); n],
+            vec![Scalar::zero(); n],
+        )
     }
 
     /// Compute an inner product of `lhs`, `rhs` which have the property that:
@@ -145,7 +148,7 @@ impl VecPoly3 {
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
         let n = self.0.len();
-        let mut out: Vec<Scalar> = (0..n).map(|_| Scalar::zero()).collect();
+        let mut out = vec![Scalar::zero(); n];
         for i in 0..n {
             out[i] = self.0[i] + x * (self.1[i] + x * (self.2[i] + x * self.3[i]));
         }
@@ -282,8 +285,18 @@ mod tests {
 
     #[test]
     fn test_inner_product() {
-        let a: Vec<Scalar> = (1..5).map(|i| Scalar::from(i as u64)).collect();
-        let b: Vec<Scalar> = (2..6).map(|i| Scalar::from(i as u64)).collect();
+        let a = vec![
+            Scalar::from(1u64),
+            Scalar::from(2u64),
+            Scalar::from(3u64),
+            Scalar::from(4u64),
+        ];
+        let b = vec![
+            Scalar::from(2u64),
+            Scalar::from(3u64),
+            Scalar::from(4u64),
+            Scalar::from(5u64),
+        ];
         assert_eq!(Scalar::from(40u64), inner_product(&a, &b));
     }
 
@@ -341,8 +354,7 @@ mod tests {
 
     #[test]
     fn vec_of_scalars_clear_on_drop() {
-        let mut v = Vec::new();
-        v.extend_from_slice(&[Scalar::from(24u64), Scalar::from(42u64)]);
+        let mut v = vec![Scalar::from(24u64), Scalar::from(42u64)];
 
         for e in v.iter_mut() {
             e.clear();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,13 @@
 #![deny(missing_docs)]
 #![allow(non_snake_case)]
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+        use alloc::vec::Vec;
+    }
+}
+
 use clear_on_drop::clear::Clear;
 use curve25519_dalek::scalar::Scalar;
 use inner_product_proof::inner_product;

--- a/src/util.rs
+++ b/src/util.rs
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn vec_of_scalars_clear_on_drop() {
         let mut v = Vec::new();
-        v.extend_from_slice([Scalar::from(24u64), Scalar::from(42u64)]);
+        v.extend_from_slice(&[Scalar::from(24u64), Scalar::from(42u64)]);
 
         for e in v.iter_mut() {
             e.clear();

--- a/src/util.rs
+++ b/src/util.rs
@@ -116,12 +116,7 @@ impl VecPoly1 {
 impl VecPoly3 {
     pub fn zero(n: usize) -> Self {
         let zn: Vec<Scalar> = (0..n).map(|_| Scalar::zero()).collect();
-        VecPoly3(
-            zn.clone(),
-            zn.clone(),
-            zn.clone(),
-            zn.clone(),
-        )
+        VecPoly3(zn.clone(), zn.clone(), zn.clone(), zn.clone())
     }
 
     /// Compute an inner product of `lhs`, `rhs` which have the property that:

--- a/src/util.rs
+++ b/src/util.rs
@@ -82,7 +82,8 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
 
 impl VecPoly1 {
     pub fn zero(n: usize) -> Self {
-        VecPoly1(vec![Scalar::zero(); n], vec![Scalar::zero(); n])
+        let zn: Vec<Scalar> = (0..n).map(|_| Scalar::zero()).collect();
+        VecPoly1(zn.clone(), zn)
     }
 
     pub fn inner_product(&self, rhs: &VecPoly1) -> Poly2 {
@@ -103,7 +104,7 @@ impl VecPoly1 {
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
         let n = self.0.len();
-        let mut out = vec![Scalar::zero(); n];
+        let mut out: Vec<Scalar> = (0..n).map(|_| Scalar::zero()).collect();
         for i in 0..n {
             out[i] = self.0[i] + self.1[i] * x;
         }
@@ -114,11 +115,12 @@ impl VecPoly1 {
 #[cfg(feature = "yoloproofs")]
 impl VecPoly3 {
     pub fn zero(n: usize) -> Self {
+        let zn: Vec<Scalar> = (0..n).map(|_| Scalar::zero()).collect();
         VecPoly3(
-            vec![Scalar::zero(); n],
-            vec![Scalar::zero(); n],
-            vec![Scalar::zero(); n],
-            vec![Scalar::zero(); n],
+            zn.clone(),
+            zn.clone(),
+            zn.clone(),
+            zn.clone(),
         )
     }
 
@@ -148,7 +150,7 @@ impl VecPoly3 {
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
         let n = self.0.len();
-        let mut out = vec![Scalar::zero(); n];
+        let mut out: Vec<Scalar> = (0..n).map(|_| Scalar::zero()).collect();
         for i in 0..n {
             out[i] = self.0[i] + x * (self.1[i] + x * (self.2[i] + x * self.3[i]));
         }
@@ -285,18 +287,8 @@ mod tests {
 
     #[test]
     fn test_inner_product() {
-        let a = vec![
-            Scalar::from(1u64),
-            Scalar::from(2u64),
-            Scalar::from(3u64),
-            Scalar::from(4u64),
-        ];
-        let b = vec![
-            Scalar::from(2u64),
-            Scalar::from(3u64),
-            Scalar::from(4u64),
-            Scalar::from(5u64),
-        ];
+        let a: Vec<Scalar> = (1..5).map(|i| Scalar::from(i as u64)).collect();
+        let b: Vec<Scalar> = (2..6).map(|i| Scalar::from(i as u64)).collect();
         assert_eq!(Scalar::from(40u64), inner_product(&a, &b));
     }
 
@@ -354,7 +346,8 @@ mod tests {
 
     #[test]
     fn vec_of_scalars_clear_on_drop() {
-        let mut v = vec![Scalar::from(24u64), Scalar::from(42u64)];
+        let mut v = Vec::new();
+        v.extend_from_slice([Scalar::from(24u64), Scalar::from(42u64)]);
 
         for e in v.iter_mut() {
             e.clear();

--- a/tests/range_proof.rs
+++ b/tests/range_proof.rs
@@ -88,13 +88,17 @@ fn deserialize_and_verify() {
     for i in 0..4 {
         for j in 0..4 {
             let (n, m) = (8 << i, 1 << j);
-            let proof = RangeProof::from_bytes(&hex::decode(&proofs[i][j]).unwrap())
-                .expect("Rangeproof deserialization failed");
-            let mut transcript = Transcript::new(b"Deserialize-And-Verify Test");
-            assert_eq!(
-                proof.verify_multiple(&bp_gens, &pc_gens, &mut transcript, &vc[0..m], n,),
-                Ok(())
-            );
+            println!("n,m = {}, {}", n, m);
+            // XXX 64,8 is not working, disable it
+            if n != 64 || m != 8 {
+                let proof = RangeProof::from_bytes(&hex::decode(&proofs[i][j]).unwrap())
+                    .expect("Rangeproof deserialization failed");
+                let mut transcript = Transcript::new(b"Deserialize-And-Verify Test");
+                assert_eq!(
+                    proof.verify_multiple(&bp_gens, &pc_gens, &mut transcript, &vc[0..m], n,),
+                    Ok(())
+                );
+            }
         }
     }
 }

--- a/tests/range_proof.rs
+++ b/tests/range_proof.rs
@@ -88,17 +88,13 @@ fn deserialize_and_verify() {
     for i in 0..4 {
         for j in 0..4 {
             let (n, m) = (8 << i, 1 << j);
-            println!("n,m = {}, {}", n, m);
-            // XXX 64,8 is not working, disable it
-            if n != 64 || m != 8 {
-                let proof = RangeProof::from_bytes(&hex::decode(&proofs[i][j]).unwrap())
-                    .expect("Rangeproof deserialization failed");
-                let mut transcript = Transcript::new(b"Deserialize-And-Verify Test");
-                assert_eq!(
-                    proof.verify_multiple(&bp_gens, &pc_gens, &mut transcript, &vc[0..m], n,),
-                    Ok(())
-                );
-            }
+            let proof = RangeProof::from_bytes(&hex::decode(&proofs[i][j]).unwrap())
+                .expect("Rangeproof deserialization failed");
+            let mut transcript = Transcript::new(b"Deserialize-And-Verify Test");
+            assert_eq!(
+                proof.verify_multiple(&bp_gens, &pc_gens, &mut transcript, &vc[0..m], n,),
+                Ok(())
+            );
         }
     }
 }


### PR DESCRIPTION
This change implements no_std support for the bulletproofs crate.  The changes are mostly mechanical.  This is the culmination several PRs worth of work, with changes to curve25519 and merlin crates already merged and released.

It was necessary to make minor modifications to some APIs, particularly in regards to RNGs.  As discussed by @isislovecruft in #275, the APIs in this change are backwards compatible for those building the crate in std mode.  So current users of the bulletproofs crate will see no change.  Users wishing to build bulletproofs in no_std mode will need to call the new *_with_rng prove and verfiy functions, and pass in a RNG.

This change is based on the main branch rather than the develop branch.  This is because the main branch in the dalek repo has several changes that are not in the develop branch.  This made rebasing my change on the upstream develop branch to be problematic.  
