### PR TITLE
Incorrect path for doc include range proof and r1cs

### DIFF
--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1,6 +1,6 @@
-#![doc(include = "../docs/r1cs-docs-example.md")]
+#![doc(include = "../../docs/r1cs-docs-example.md")]
 
-#[doc(include = "../docs/cs-proof.md")]
+#[doc(include = "../../docs/cs-proof.md")]
 mod notes {}
 
 mod constraint_system;

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -1,5 +1,5 @@
 #![allow(non_snake_case)]
-#![doc(include = "../docs/range-proof-protocol.md")]
+#![doc(include = "../../docs/range-proof-protocol.md")]
 
 use rand;
 


### PR DESCRIPTION
```
error: couldn't read src/range_proof/../docs/range-proof-protocol.md: No such file or directory (os error 2)
 --> src/range_proof/mod.rs:2:18
  |
2 | #![doc(include = "../docs/range-proof-protocol.md")]
  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ couldn't read file
```

```
$ rustc --version
rustc 1.38.0-nightly (4560cb830 2019-07-28)
```