### PR TITLE
updated the path to fix compilation error

### DIFF
--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -1,5 +1,5 @@
 #![allow(non_snake_case)]
-#![doc(include = "../docs/range-proof-protocol.md")]
+#![doc(include = "../../docs/range-proof-protocol.md")]
 
 use rand;
 


### PR DESCRIPTION
Fixing the following error:

error: couldn't read src/range_proof/../docs/range-proof-protocol.md: No such file or directory (os error 2)
 --> src/range_proof/mod.rs:2:18
  |
2 | #![doc(include = "../docs/range-proof-protocol.md")]
  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ couldn't read file
