### PR TITLE
Strip down allocation in serialization of R1CSProof

### DIFF
--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -346,6 +346,20 @@ impl InnerProductProof {
         buf
     }
 
+    /// Converts the proof into a byte iterator over serialized view of the proof.
+    /// The layout of the inner product proof is:
+    /// * \\(n\\) pairs of compressed Ristretto points \\(L_0, R_0 \dots, L_{n-1}, R_{n-1}\\),
+    /// * two scalars \\(a, b\\).
+    #[inline]
+    pub fn to_bytes_iter(&self) -> impl Iterator<Item = u8> + '_ {
+        self.L_vec.iter()
+            .zip(self.R_vec_iter())
+            .flat_map(|(l, r)| l.as_bytes().iter().chain(r.as_bytes()))
+            .chain(self.a.as_bytes())
+            .chain(self.b.as_bytes())
+            .copied()
+    }
+
     /// Deserializes the proof from a byte slice.
     /// Returns an error in the following cases:
     /// * the slice does not have \\(2n+2\\) 32-byte elements,

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -104,8 +104,7 @@ impl R1CSProof {
         buf.extend_from_slice(self.t_x.as_bytes());
         buf.extend_from_slice(self.t_x_blinding.as_bytes());
         buf.extend_from_slice(self.e_blinding.as_bytes());
-        // XXX this costs an extra alloc
-        buf.extend_from_slice(self.ipp_proof.to_bytes().as_slice());
+        buf.extend(self.ipp_proof.to_bytes_iter());
         buf
     }
 


### PR DESCRIPTION
This PR adds `InnerProductProof::to_bytes_iter` which similar to `proof.to_bytes().into_iter()`, but doesn't allocate, and uses it in serialization of `R1CSProof`.

Unresolved questions:

- [ ] Should it be public API?