### PR TITLE
Update rand_core, curve25519-dalek, merlin versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,24 +12,24 @@ keywords = ["cryptography", "crypto", "ristretto", "zero-knowledge", "bulletproo
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
-curve25519-dalek = { version = "^1.2.3", default-features = false, features = ["u64_backend", "nightly", "serde", "alloc"] }
+curve25519-dalek = { version = "2", default-features = false, features = ["u64_backend", "nightly", "serde", "alloc"] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 digest = { version = "0.8", default-features = false }
-rand_core = { version = "0.4", default-features = false, features = ["alloc"] }
-rand = { version = "0.6", default-features = false, optional = true }
+rand_core = { version = "0.5", default-features = false, features = ["alloc"] }
+rand = { version = "0.7", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1", default-features = false }
 failure = { version = "0.1", default-features = false, features = ["derive"] }
-merlin = { version = "1.2", default-features = false }
+merlin = { version = "2", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false, features = ["nightly"] }
 
 [dev-dependencies]
 hex = "0.3"
 criterion = "0.2"
 bincode = "1"
-rand_chacha = "0.1"
+rand_chacha = "0.2"
 
 [features]
 default = ["std", "avx2_backend"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clear_on_drop = { version = "0.2", default-features = false, features = ["nightl
 
 [dev-dependencies]
 hex = "0.3"
-criterion = "0.2"
+criterion = "0.3"
 bincode = "1"
 rand_chacha = "0.2"
 

--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -23,7 +23,8 @@ use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
-use rand::{thread_rng, Rng};
+use rand::{Rng};
+use rand::seq::SliceRandom;
 
 // Shuffle gadget (documented in markdown file)
 
@@ -177,7 +178,7 @@ fn bench_kshuffle_prove(c: &mut Criterion) {
                 .map(|_| Scalar::from(rng.gen_range(min, max)))
                 .collect();
             let mut output = input.clone();
-            rand::thread_rng().shuffle(&mut output);
+            output.shuffle(&mut rand::thread_rng());
 
             // Make kshuffle proof
             b.iter(|| {
@@ -219,7 +220,7 @@ fn bench_kshuffle_verify(c: &mut Criterion) {
                     .map(|_| Scalar::from(rng.gen_range(min, max)))
                     .collect();
                 let mut output = input.clone();
-                rand::thread_rng().shuffle(&mut output);
+                output.shuffle(&mut rand::thread_rng());
 
                 let mut prover_transcript = Transcript::new(b"ShuffleBenchmark");
 

--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -23,8 +23,8 @@ use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
-use rand::{Rng};
 use rand::seq::SliceRandom;
+use rand::Rng;
 
 // Shuffle gadget (documented in markdown file)
 

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -10,6 +10,7 @@ use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
+use rand::seq::SliceRandom;
 use rand::thread_rng;
 
 // Shuffle gadget (documented in markdown file)
@@ -157,7 +158,7 @@ fn kshuffle_helper(k: usize) {
             .map(|_| Scalar::from(rng.gen_range(min, max)))
             .collect();
         let mut output = input.clone();
-        rand::thread_rng().shuffle(&mut output);
+        output.shuffle(&mut rand::thread_rng());
 
         let mut prover_transcript = Transcript::new(b"ShuffleProofTest");
         ShuffleProof::prove(&pc_gens, &bp_gens, &mut prover_transcript, &input, &output).unwrap()
@@ -401,10 +402,10 @@ pub fn range_proof<CS: ConstraintSystem>(
 
 #[test]
 fn range_proof_gadget() {
-    use rand::rngs::OsRng;
+    use rand::thread_rng;
     use rand::Rng;
 
-    let mut rng = OsRng::new().unwrap();
+    let mut rng = thread_rng();
     let m = 3; // number of values to test per `n`
 
     for n in [2, 10, 32, 63].iter() {

--- a/tests/range_proof.rs
+++ b/tests/range_proof.rs
@@ -1,5 +1,5 @@
-extern crate rand;
-use rand::SeedableRng;
+extern crate rand_core;
+use rand_core::SeedableRng;
 
 extern crate rand_chacha;
 use rand_chacha::ChaChaRng;


### PR DESCRIPTION
This is a breaking API change that will require a `2.0.0` version, but it keeps the crate up-to-date with the rand ecosystem. A possible further simplification of the dep tree would be to replace `clear_on_drop` by `zeroize`, but this could be done at any later point because `clear_on_drop` is an implementation detail.