### PR TITLE
Curve v2 (on develop branch)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["cryptography", "crypto", "ristretto", "zero-knowledge", "bulletproo
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
-curve25519-dalek = { version = "^1.2.3", default-features = false, features = ["u64_backend", "nightly", "serde", "alloc"] }
+curve25519-dalek = { version = "2", default-features = false, features = ["u64_backend", "nightly", "serde", "alloc"] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 digest = { version = "0.8", default-features = false }
-rand_core = { version = "0.4", default-features = false, features = ["alloc"] }
-rand = { version = "0.6", default-features = false, optional = true }
+rand_core = { version = "0.5", default-features = false, features = ["alloc"] }
+rand = { version = "0.7", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clear_on_drop = { version = "0.2", default-features = false, features = ["nightl
 hex = "0.3"
 criterion = "0.2"
 bincode = "1"
-rand_chacha = "0.1"
+rand_chacha = "0.2"
 
 [features]
 default = ["std", "avx2_backend"]

--- a/tests/range_proof.rs
+++ b/tests/range_proof.rs
@@ -1,8 +1,7 @@
-extern crate rand;
-use rand::SeedableRng;
-
 extern crate rand_chacha;
 use rand_chacha::ChaChaRng;
+
+extern crate rand_core;
 
 extern crate curve25519_dalek;
 use curve25519_dalek::ristretto::CompressedRistretto;
@@ -110,6 +109,7 @@ fn generate_test_vectors() {
 
     // Use a deterministic RNG for proving, so the test vectors can be
     // generated reproducibly.
+    use rand_core::SeedableRng;
     let mut test_rng = ChaChaRng::from_seed([24u8; 32]);
 
     let values = vec![0u64, 1, 2, 3, 4, 5, 6, 7];


### PR DESCRIPTION
Uprev curve25519-dalek to v2 and use matching rand and rand_core versions (matching current master)

We need this because we are using bulletproofs/develop branch (for no_std support) and we also need to uprev curve25519-dalek to v2 (because the old version has a build.rs and depends on byteorder, but we also have build-dependencies that turn on byteorder/std, breaking our no_std build)