### PR TITLE
r1cs: accept ownable transcript

### DIFF
--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use clear_on_drop::clear::Clear;
+use core::borrow::BorrowMut;
 use core::mem;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
@@ -26,11 +27,25 @@ use crate::transcript::TranscriptProtocol;
 /// When all constraints are added, the proving code calls `prove`
 /// which consumes the `Prover` instance, samples random challenges
 /// that instantiate the randomized constraints, and creates a complete proof.
-pub struct Prover<'t, 'g> {
-    transcript: &'t mut Transcript,
+pub struct Prover<'g, T: BorrowMut<Transcript>> {
+    transcript: T,
     pc_gens: &'g PedersenGens,
     /// The constraints accumulated so far.
     constraints: Vec<LinearCombination>,
+    /// Secret data
+    secrets: Secrets,
+
+    /// This list holds closures that will be called in the second phase of the protocol,
+    /// when non-randomized variables are committed.
+    deferred_constraints: Vec<Box<dyn Fn(&mut RandomizingProver<'g, T>) -> Result<(), R1CSError>>>,
+
+    /// Index of a pending multiplier that's not fully assigned yet.
+    pending_multiplier: Option<usize>,
+}
+
+/// Separate struct to implement Drop trait for (for zeroing),
+/// so that compiler does not prohibit us from moving the Transcript out of `prove()`.
+struct Secrets {
     /// Stores assignments to the "left" of multiplication gates
     a_L: Vec<Scalar>,
     /// Stores assignments to the "right" of multiplication gates
@@ -41,13 +56,6 @@ pub struct Prover<'t, 'g> {
     v: Vec<Scalar>,
     /// High-level witness data (blinding openings to V commitments)
     v_blinding: Vec<Scalar>,
-
-    /// This list holds closures that will be called in the second phase of the protocol,
-    /// when non-randomized variables are committed.
-    deferred_constraints: Vec<Box<dyn Fn(&mut RandomizingProver<'t, 'g>) -> Result<(), R1CSError>>>,
-
-    /// Index of a pending multiplier that's not fully assigned yet.
-    pending_multiplier: Option<usize>,
 }
 
 /// Prover in the randomizing phase.
@@ -57,12 +65,12 @@ pub struct Prover<'t, 'g> {
 /// monomorphize the closures for the proving and verifying code.
 /// However, this type cannot be instantiated by the user and therefore can only be used within
 /// the callback provided to `specify_randomized_constraints`.
-pub struct RandomizingProver<'t, 'g> {
-    prover: Prover<'t, 'g>,
+pub struct RandomizingProver<'g, T: BorrowMut<Transcript>> {
+    prover: Prover<'g, T>,
 }
 
 /// Overwrite secrets with null bytes when they go out of scope.
-impl<'t, 'g> Drop for Prover<'t, 'g> {
+impl Drop for Secrets {
     fn drop(&mut self) {
         self.v.clear();
         self.v_blinding.clear();
@@ -85,9 +93,9 @@ impl<'t, 'g> Drop for Prover<'t, 'g> {
     }
 }
 
-impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
+impl<'g, T: BorrowMut<Transcript>> ConstraintSystem for Prover<'g, T> {
     fn transcript(&mut self) -> &mut Transcript {
-        self.transcript
+        self.transcript.borrow_mut()
     }
 
     fn multiply(
@@ -101,13 +109,13 @@ impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
         let o = l * r;
 
         // Create variables for l,r,o ...
-        let l_var = Variable::MultiplierLeft(self.a_L.len());
-        let r_var = Variable::MultiplierRight(self.a_R.len());
-        let o_var = Variable::MultiplierOutput(self.a_O.len());
+        let l_var = Variable::MultiplierLeft(self.secrets.a_L.len());
+        let r_var = Variable::MultiplierRight(self.secrets.a_R.len());
+        let o_var = Variable::MultiplierOutput(self.secrets.a_O.len());
         // ... and assign them
-        self.a_L.push(l);
-        self.a_R.push(r);
-        self.a_O.push(o);
+        self.secrets.a_L.push(l);
+        self.secrets.a_R.push(r);
+        self.secrets.a_O.push(o);
 
         // Constrain l,r,o:
         left.terms.push((l_var, -Scalar::one()));
@@ -123,17 +131,17 @@ impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
 
         match self.pending_multiplier {
             None => {
-                let i = self.a_L.len();
+                let i = self.secrets.a_L.len();
                 self.pending_multiplier = Some(i);
-                self.a_L.push(scalar);
-                self.a_R.push(Scalar::zero());
-                self.a_O.push(Scalar::zero());
+                self.secrets.a_L.push(scalar);
+                self.secrets.a_R.push(Scalar::zero());
+                self.secrets.a_O.push(Scalar::zero());
                 Ok(Variable::MultiplierLeft(i))
             }
             Some(i) => {
                 self.pending_multiplier = None;
-                self.a_R[i] = scalar;
-                self.a_O[i] = self.a_L[i] * self.a_R[i];
+                self.secrets.a_R[i] = scalar;
+                self.secrets.a_O[i] = self.secrets.a_L[i] * self.secrets.a_R[i];
                 Ok(Variable::MultiplierRight(i))
             }
         }
@@ -147,19 +155,19 @@ impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
         let o = l * r;
 
         // Create variables for l,r,o ...
-        let l_var = Variable::MultiplierLeft(self.a_L.len());
-        let r_var = Variable::MultiplierRight(self.a_R.len());
-        let o_var = Variable::MultiplierOutput(self.a_O.len());
+        let l_var = Variable::MultiplierLeft(self.secrets.a_L.len());
+        let r_var = Variable::MultiplierRight(self.secrets.a_R.len());
+        let o_var = Variable::MultiplierOutput(self.secrets.a_O.len());
         // ... and assign them
-        self.a_L.push(l);
-        self.a_R.push(r);
-        self.a_O.push(o);
+        self.secrets.a_L.push(l);
+        self.secrets.a_R.push(r);
+        self.secrets.a_O.push(o);
 
         Ok((l_var, r_var, o_var))
     }
 
     fn multipliers_len(&self) -> usize {
-        self.a_L.len()
+        self.secrets.a_L.len()
     }
 
     fn constrain(&mut self, lc: LinearCombination) {
@@ -169,8 +177,8 @@ impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
     }
 }
 
-impl<'t, 'g> RandomizableConstraintSystem for Prover<'t, 'g> {
-    type RandomizedCS = RandomizingProver<'t, 'g>;
+impl<'g, T: BorrowMut<Transcript>> RandomizableConstraintSystem for Prover<'g, T> {
+    type RandomizedCS = RandomizingProver<'g, T>;
 
     fn specify_randomized_constraints<F>(&mut self, callback: F) -> Result<(), R1CSError>
     where
@@ -181,9 +189,9 @@ impl<'t, 'g> RandomizableConstraintSystem for Prover<'t, 'g> {
     }
 }
 
-impl<'t, 'g> ConstraintSystem for RandomizingProver<'t, 'g> {
+impl<'g, T: BorrowMut<Transcript>> ConstraintSystem for RandomizingProver<'g, T> {
     fn transcript(&mut self) -> &mut Transcript {
-        self.prover.transcript
+        self.prover.transcript.borrow_mut()
     }
 
     fn multiply(
@@ -214,13 +222,13 @@ impl<'t, 'g> ConstraintSystem for RandomizingProver<'t, 'g> {
     }
 }
 
-impl<'t, 'g> RandomizedConstraintSystem for RandomizingProver<'t, 'g> {
+impl<'g, T: BorrowMut<Transcript>> RandomizedConstraintSystem for RandomizingProver<'g, T> {
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar {
-        self.prover.transcript.challenge_scalar(label)
+        self.prover.transcript.borrow_mut().challenge_scalar(label)
     }
 }
 
-impl<'t, 'g> Prover<'t, 'g> {
+impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
     /// Construct an empty constraint system with specified external
     /// input variables.
     ///
@@ -241,18 +249,20 @@ impl<'t, 'g> Prover<'t, 'g> {
     /// # Returns
     ///
     /// Returns a new `Prover` instance.
-    pub fn new(pc_gens: &'g PedersenGens, transcript: &'t mut Transcript) -> Self {
-        transcript.r1cs_domain_sep();
+    pub fn new(pc_gens: &'g PedersenGens, mut transcript: T) -> Self {
+        transcript.borrow_mut().r1cs_domain_sep();
 
         Prover {
             pc_gens,
             transcript,
-            v: Vec::new(),
-            v_blinding: Vec::new(),
+            secrets: Secrets {
+                v: Vec::new(),
+                v_blinding: Vec::new(),
+                a_L: Vec::new(),
+                a_R: Vec::new(),
+                a_O: Vec::new(),
+            },
             constraints: Vec::new(),
-            a_L: Vec::new(),
-            a_R: Vec::new(),
-            a_O: Vec::new(),
             deferred_constraints: Vec::new(),
             pending_multiplier: None,
         }
@@ -276,13 +286,13 @@ impl<'t, 'g> Prover<'t, 'g> {
     /// Returns a pair of a Pedersen commitment (as a compressed Ristretto point),
     /// and a [`Variable`] corresponding to it, which can be used to form constraints.
     pub fn commit(&mut self, v: Scalar, v_blinding: Scalar) -> (CompressedRistretto, Variable) {
-        let i = self.v.len();
-        self.v.push(v);
-        self.v_blinding.push(v_blinding);
+        let i = self.secrets.v.len();
+        self.secrets.v.push(v);
+        self.secrets.v_blinding.push(v_blinding);
 
         // Add the commitment to the transcript.
         let V = self.pc_gens.commit(v, v_blinding).compress();
-        self.transcript.append_point(b"V", &V);
+        self.transcript.borrow_mut().append_point(b"V", &V);
 
         (V, Variable::Committed(i))
     }
@@ -302,8 +312,8 @@ impl<'t, 'g> Prover<'t, 'g> {
         &mut self,
         z: &Scalar,
     ) -> (Vec<Scalar>, Vec<Scalar>, Vec<Scalar>, Vec<Scalar>) {
-        let n = self.a_L.len();
-        let m = self.v.len();
+        let n = self.secrets.a_L.len();
+        let m = self.secrets.v.len();
 
         let mut wL = vec![Scalar::zero(); n];
         let mut wR = vec![Scalar::zero(); n];
@@ -343,10 +353,10 @@ impl<'t, 'g> Prover<'t, 'g> {
             .map(|(var, coeff)| {
                 coeff
                     * match var {
-                        Variable::MultiplierLeft(i) => self.a_L[*i],
-                        Variable::MultiplierRight(i) => self.a_R[*i],
-                        Variable::MultiplierOutput(i) => self.a_O[*i],
-                        Variable::Committed(i) => self.v[*i],
+                        Variable::MultiplierLeft(i) => self.secrets.a_L[*i],
+                        Variable::MultiplierRight(i) => self.secrets.a_R[*i],
+                        Variable::MultiplierOutput(i) => self.secrets.a_O[*i],
+                        Variable::Committed(i) => self.secrets.v[*i],
                         Variable::One() => Scalar::one(),
                     }
             })
@@ -360,10 +370,10 @@ impl<'t, 'g> Prover<'t, 'g> {
         self.pending_multiplier = None;
 
         if self.deferred_constraints.len() == 0 {
-            self.transcript.r1cs_1phase_domain_sep();
+            self.transcript.borrow_mut().r1cs_1phase_domain_sep();
             Ok(self)
         } else {
-            self.transcript.r1cs_2phase_domain_sep();
+            self.transcript.borrow_mut().r1cs_2phase_domain_sep();
             // Note: the wrapper could've used &mut instead of ownership,
             // but specifying lifetimes for boxed closures is not going to be nice,
             // so we move the self into wrapper and then move it back out afterwards.
@@ -377,7 +387,16 @@ impl<'t, 'g> Prover<'t, 'g> {
     }
 
     /// Consume this `ConstraintSystem` to produce a proof.
-    pub fn prove(mut self, bp_gens: &BulletproofGens) -> Result<R1CSProof, R1CSError> {
+    pub fn prove(self, bp_gens: &BulletproofGens) -> Result<R1CSProof, R1CSError> {
+        self.prove_and_return_transcript(bp_gens)
+            .map(|(proof, _transcript)| proof)
+    }
+
+    /// Consume this `ConstraintSystem` to produce a proof. Returns the proof and the transcript passed in `Prover::new`.
+    pub fn prove_and_return_transcript(
+        mut self,
+        bp_gens: &BulletproofGens,
+    ) -> Result<(R1CSProof, T), R1CSError> {
         use crate::util;
         use std::iter;
 
@@ -385,7 +404,9 @@ impl<'t, 'g> Prover<'t, 'g> {
         // We cannot do this in advance because user can commit variables one-by-one,
         // but this suffix provides safe disambiguation because each variable
         // is prefixed with a separate label.
-        self.transcript.append_u64(b"m", self.v.len() as u64);
+        self.transcript
+            .borrow_mut()
+            .append_u64(b"m", self.secrets.v.len() as u64);
 
         // Create a `TranscriptRng` from the high-level witness data
         //
@@ -401,10 +422,10 @@ impl<'t, 'g> Prover<'t, 'g> {
         // protect the v's in the commitments), we don't gain much by
         // committing the v's as well as the v_blinding's.
         let mut rng = {
-            let mut builder = self.transcript.build_rng();
+            let mut builder = self.transcript.borrow_mut().build_rng();
 
             // Commit the blinding factors for the input wires
-            for v_b in &self.v_blinding {
+            for v_b in &self.secrets.v_blinding {
                 builder = builder.rekey_with_witness_bytes(b"v_blinding", v_b.as_bytes());
             }
 
@@ -413,7 +434,7 @@ impl<'t, 'g> Prover<'t, 'g> {
         };
 
         // Commit to the first-phase low-level witness variables.
-        let n1 = self.a_L.len();
+        let n1 = self.secrets.a_L.len();
 
         if bp_gens.gens_capacity < n1 {
             return Err(R1CSError::InvalidGeneratorsLength);
@@ -432,8 +453,8 @@ impl<'t, 'g> Prover<'t, 'g> {
         // A_I = <a_L, G> + <a_R, H> + i_blinding * B_blinding
         let A_I1 = RistrettoPoint::multiscalar_mul(
             iter::once(&i_blinding1)
-                .chain(self.a_L.iter())
-                .chain(self.a_R.iter()),
+                .chain(self.secrets.a_L.iter())
+                .chain(self.secrets.a_R.iter()),
             iter::once(&self.pc_gens.B_blinding)
                 .chain(gens.G(n1))
                 .chain(gens.H(n1)),
@@ -442,7 +463,7 @@ impl<'t, 'g> Prover<'t, 'g> {
 
         // A_O = <a_O, G> + o_blinding * B_blinding
         let A_O1 = RistrettoPoint::multiscalar_mul(
-            iter::once(&o_blinding1).chain(self.a_O.iter()),
+            iter::once(&o_blinding1).chain(self.secrets.a_O.iter()),
             iter::once(&self.pc_gens.B_blinding).chain(gens.G(n1)),
         )
         .compress();
@@ -458,9 +479,10 @@ impl<'t, 'g> Prover<'t, 'g> {
         )
         .compress();
 
-        self.transcript.append_point(b"A_I1", &A_I1);
-        self.transcript.append_point(b"A_O1", &A_O1);
-        self.transcript.append_point(b"S1", &S1);
+        let transcript = self.transcript.borrow_mut();
+        transcript.append_point(b"A_I1", &A_I1);
+        transcript.append_point(b"A_O1", &A_O1);
+        transcript.append_point(b"S1", &S1);
 
         // Process the remaining constraints.
         self = self.create_randomized_constraints()?;
@@ -468,9 +490,9 @@ impl<'t, 'g> Prover<'t, 'g> {
         // Pad zeros to the next power of two (or do that implicitly when creating vectors)
 
         // If the number of multiplications is not 0 or a power of 2, then pad the circuit.
-        let n = self.a_L.len();
+        let n = self.secrets.a_L.len();
         let n2 = n - n1;
-        let padded_n = self.a_L.len().next_power_of_two();
+        let padded_n = self.secrets.a_L.len().next_power_of_two();
         let pad = padded_n - n;
 
         if bp_gens.gens_capacity < padded_n {
@@ -499,8 +521,8 @@ impl<'t, 'g> Prover<'t, 'g> {
                 // A_I = <a_L, G> + <a_R, H> + i_blinding * B_blinding
                 RistrettoPoint::multiscalar_mul(
                     iter::once(&i_blinding2)
-                        .chain(self.a_L.iter().skip(n1))
-                        .chain(self.a_R.iter().skip(n1)),
+                        .chain(self.secrets.a_L.iter().skip(n1))
+                        .chain(self.secrets.a_R.iter().skip(n1)),
                     iter::once(&self.pc_gens.B_blinding)
                         .chain(gens.G(n).skip(n1))
                         .chain(gens.H(n).skip(n1)),
@@ -508,7 +530,7 @@ impl<'t, 'g> Prover<'t, 'g> {
                 .compress(),
                 // A_O = <a_O, G> + o_blinding * B_blinding
                 RistrettoPoint::multiscalar_mul(
-                    iter::once(&o_blinding2).chain(self.a_O.iter().skip(n1)),
+                    iter::once(&o_blinding2).chain(self.secrets.a_O.iter().skip(n1)),
                     iter::once(&self.pc_gens.B_blinding).chain(gens.G(n).skip(n1)),
                 )
                 .compress(),
@@ -535,14 +557,15 @@ impl<'t, 'g> Prover<'t, 'g> {
             )
         };
 
-        self.transcript.append_point(b"A_I2", &A_I2);
-        self.transcript.append_point(b"A_O2", &A_O2);
-        self.transcript.append_point(b"S2", &S2);
+        let transcript = self.transcript.borrow_mut();
+        transcript.append_point(b"A_I2", &A_I2);
+        transcript.append_point(b"A_O2", &A_O2);
+        transcript.append_point(b"S2", &S2);
 
         // 4. Compute blinded vector polynomials l(x) and r(x)
 
-        let y = self.transcript.challenge_scalar(b"y");
-        let z = self.transcript.challenge_scalar(b"z");
+        let y = transcript.challenge_scalar(b"y");
+        let z = transcript.challenge_scalar(b"z");
 
         let (wL, wR, wO, wV) = self.flattened_constraints(&z);
 
@@ -560,15 +583,15 @@ impl<'t, 'g> Prover<'t, 'g> {
         for (i, (sl, sr)) in sLsR.enumerate() {
             // l_poly.0 = 0
             // l_poly.1 = a_L + y^-n * (z * z^Q * W_R)
-            l_poly.1[i] = self.a_L[i] + exp_y_inv[i] * wR[i];
+            l_poly.1[i] = self.secrets.a_L[i] + exp_y_inv[i] * wR[i];
             // l_poly.2 = a_O
-            l_poly.2[i] = self.a_O[i];
+            l_poly.2[i] = self.secrets.a_O[i];
             // l_poly.3 = s_L
             l_poly.3[i] = *sl;
             // r_poly.0 = (z * z^Q * W_O) - y^n
             r_poly.0[i] = wO[i] - exp_y;
             // r_poly.1 = y^n * a_R + (z * z^Q * W_L)
-            r_poly.1[i] = exp_y * self.a_R[i] + wL[i];
+            r_poly.1[i] = exp_y * self.secrets.a_R[i] + wL[i];
             // r_poly.2 = 0
             // r_poly.3 = y^n * s_R
             r_poly.3[i] = exp_y * sr;
@@ -590,20 +613,21 @@ impl<'t, 'g> Prover<'t, 'g> {
         let T_5 = self.pc_gens.commit(t_poly.t5, t_5_blinding).compress();
         let T_6 = self.pc_gens.commit(t_poly.t6, t_6_blinding).compress();
 
-        self.transcript.append_point(b"T_1", &T_1);
-        self.transcript.append_point(b"T_3", &T_3);
-        self.transcript.append_point(b"T_4", &T_4);
-        self.transcript.append_point(b"T_5", &T_5);
-        self.transcript.append_point(b"T_6", &T_6);
+        let transcript = self.transcript.borrow_mut();
+        transcript.append_point(b"T_1", &T_1);
+        transcript.append_point(b"T_3", &T_3);
+        transcript.append_point(b"T_4", &T_4);
+        transcript.append_point(b"T_5", &T_5);
+        transcript.append_point(b"T_6", &T_6);
 
-        let u = self.transcript.challenge_scalar(b"u");
-        let x = self.transcript.challenge_scalar(b"x");
+        let u = transcript.challenge_scalar(b"u");
+        let x = transcript.challenge_scalar(b"x");
 
         // t_2_blinding = <z*z^Q, W_V * v_blinding>
         // in the t_x_blinding calculations, line 76.
         let t_2_blinding = wV
             .iter()
-            .zip(self.v_blinding.iter())
+            .zip(self.secrets.v_blinding.iter())
             .map(|(c, v_blinding)| c * v_blinding)
             .sum();
 
@@ -636,13 +660,12 @@ impl<'t, 'g> Prover<'t, 'g> {
 
         let e_blinding = x * (i_blinding + x * (o_blinding + x * s_blinding));
 
-        self.transcript.append_scalar(b"t_x", &t_x);
-        self.transcript
-            .append_scalar(b"t_x_blinding", &t_x_blinding);
-        self.transcript.append_scalar(b"e_blinding", &e_blinding);
+        transcript.append_scalar(b"t_x", &t_x);
+        transcript.append_scalar(b"t_x_blinding", &t_x_blinding);
+        transcript.append_scalar(b"e_blinding", &e_blinding);
 
         // Get a challenge value to combine statements for the IPP
-        let w = self.transcript.challenge_scalar(b"w");
+        let w = transcript.challenge_scalar(b"w");
         let Q = w * self.pc_gens.B;
 
         let G_factors = iter::repeat(Scalar::one())
@@ -656,7 +679,7 @@ impl<'t, 'g> Prover<'t, 'g> {
             .collect::<Vec<_>>();
 
         let ipp_proof = InnerProductProof::create(
-            self.transcript,
+            transcript,
             &Q,
             &G_factors,
             &H_factors,
@@ -677,8 +700,7 @@ impl<'t, 'g> Prover<'t, 'g> {
         {
             scalar.clear();
         }
-
-        Ok(R1CSProof {
+        let proof = R1CSProof {
             A_I1,
             A_O1,
             S1,
@@ -694,6 +716,7 @@ impl<'t, 'g> Prover<'t, 'g> {
             t_x_blinding,
             e_blinding,
             ipp_proof,
-        })
+        };
+        Ok((proof, self.transcript))
     }
 }

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -331,6 +331,16 @@ impl<T: BorrowMut<Transcript>> Verifier<T> {
     /// the number of multiplication constraints that will eventually
     /// be added into the constraint system.
     pub fn verify(
+        self,
+        proof: &R1CSProof,
+        pc_gens: &PedersenGens,
+        bp_gens: &BulletproofGens,
+    ) -> Result<(), R1CSError> {
+        self.verify_and_return_transcript(proof, pc_gens, bp_gens)
+            .map(|_| ())
+    }
+    /// Same as `verify`, but also returns the transcript back to the user.
+    pub fn verify_and_return_transcript(
         mut self,
         proof: &R1CSProof,
         pc_gens: &PedersenGens,

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -307,8 +307,7 @@ fn example_gadget_verify(
     // 4. Verify the proof
     verifier
         .verify(&proof, &pc_gens, &bp_gens)
-        .map_err(|_| R1CSError::VerificationError)?;
-    Ok(())
+        .map_err(|_| R1CSError::VerificationError)
 }
 
 fn example_gadget_roundtrip_helper(
@@ -451,6 +450,5 @@ fn range_proof_helper(v_val: u64, n: usize) -> Result<(), R1CSError> {
     assert!(range_proof(&mut verifier, var.into(), None, n).is_ok());
 
     // Verifier verifies proof
-    verifier.verify(&proof, &pc_gens, &bp_gens)?;
-    Ok(())
+    verifier.verify(&proof, &pc_gens, &bp_gens)
 }

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -139,7 +139,8 @@ impl ShuffleProof {
 
         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 
-        verifier.verify(&self.0, &pc_gens, &bp_gens)
+        verifier.verify(&self.0, &pc_gens, &bp_gens)?;
+        Ok(())
     }
 }
 
@@ -306,7 +307,8 @@ fn example_gadget_verify(
     // 4. Verify the proof
     verifier
         .verify(&proof, &pc_gens, &bp_gens)
-        .map_err(|_| R1CSError::VerificationError)
+        .map_err(|_| R1CSError::VerificationError)?;
+    Ok(())
 }
 
 fn example_gadget_roundtrip_helper(
@@ -449,5 +451,6 @@ fn range_proof_helper(v_val: u64, n: usize) -> Result<(), R1CSError> {
     assert!(range_proof(&mut verifier, var.into(), None, n).is_ok());
 
     // Verifier verifies proof
-    Ok(verifier.verify(&proof, &pc_gens, &bp_gens)?)
+    verifier.verify(&proof, &pc_gens, &bp_gens)?;
+    Ok(())
 }


### PR DESCRIPTION
This changes the Prover/Verifier API as follows:

1. Instead of holding `&mut Transcript`, Prover/Verifier accepts `BorrowMut<Transcript>`. This means, Transcript can be passed in not only as a mutable reference, but also moved in and owned by the constraint system.
2. `Verifier::verify` and `Prover::prove` have new variants `_and_return_transcript()` that return the transcript back to the user. So if the user moved the transcript into CS, they can get it back and continue working with it.

### Rationale

The proposed API allows users to "bundle" transcript and intermediate CS state in an object, so that it can be used after the CS is built, but before the proof is created/verified. Specifically, in [ZkVM](https://github.com/stellar/slingshot/blob/main/zkvm/src/verifier.rs), the transaction effects and its ID are computed together with building a constraint system. New API would allow us to perform cheaper verification of the effects before doing a more expensive ZKP verification. Without the new API we'd need to make an extra precomputation pass to get the effects w/o ZKP verification.

### Alternative: pinned bundle around the existing API

We can probably keep the self-referential struct: the bundle would have to own a transcript and also contain a CS instance with a &mut reference to it. To make such object safe to use, it must be additionally wrapped in a pinned Box, and also we'd need some careful pointer manipulation inside `unsafe{}`. I haven't tried it out, but it does not seem very straightforward.

Pros: the API remains the same.
Cons: more complex wrapper solution.

