### PR TITLE
R1CS: Add `constraints_len`, `deferred_constraints_len` and `total_constraints_len`

### DIFF
--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -66,8 +66,8 @@ pub trait ConstraintSystem {
         input_assignments: Option<(Scalar, Scalar)>,
     ) -> Result<(Variable, Variable, Variable), R1CSError>;
 
-    /// Counts the amount of allocated multipliers.
-    fn multipliers_len(&self) -> usize;
+    /// Counts the amount of constraints in the constraint system.
+    fn metrics(&self) -> crate::r1cs::Metrics;
 
     /// Enforce the explicit constraint that
     /// ```text

--- a/src/r1cs/metrics.rs
+++ b/src/r1cs/metrics.rs
@@ -1,0 +1,10 @@
+/// A struct that contains metrics about a constraint system.
+///
+/// See [`ConstraintSystem::metrics`](::r1cs::ConstraintSystem::metrics).
+#[derive(Debug, Clone)]
+pub struct Metrics {
+    pub multipliers: usize,
+    pub constraints: usize,
+    pub phase_one_constraints: usize,
+    pub phase_two_constraints: usize,
+}

--- a/src/r1cs/metrics.rs
+++ b/src/r1cs/metrics.rs
@@ -3,8 +3,12 @@
 /// See [`ConstraintSystem::metrics`](::r1cs::ConstraintSystem::metrics).
 #[derive(Debug, Clone)]
 pub struct Metrics {
+    /// Number of multiplicative constraints in the constraint system.
     pub multipliers: usize,
+    /// Total number of linear constraints in the constraint system.
     pub constraints: usize,
+    /// Number of linear constraints added in pre-randomization phase.
     pub phase_one_constraints: usize,
+    /// Number of linear constraints added in the randomization phase.
     pub phase_two_constraints: usize,
 }

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -5,6 +5,7 @@ mod notes {}
 
 mod constraint_system;
 mod linear_combination;
+mod metrics;
 mod proof;
 mod prover;
 mod verifier;
@@ -13,6 +14,7 @@ pub use self::constraint_system::{
     ConstraintSystem, RandomizableConstraintSystem, RandomizedConstraintSystem,
 };
 pub use self::linear_combination::{LinearCombination, Variable};
+pub use self::metrics::Metrics;
 pub use self::proof::R1CSProof;
 pub use self::prover::Prover;
 pub use self::verifier::Verifier;

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -16,6 +16,7 @@ use super::{
 use crate::errors::R1CSError;
 use crate::generators::{BulletproofGens, PedersenGens};
 use crate::inner_product_proof::InnerProductProof;
+use crate::r1cs::Metrics;
 use crate::transcript::TranscriptProtocol;
 
 /// A [`ConstraintSystem`] implementation for use by the prover.
@@ -166,8 +167,13 @@ impl<'g, T: BorrowMut<Transcript>> ConstraintSystem for Prover<'g, T> {
         Ok((l_var, r_var, o_var))
     }
 
-    fn multipliers_len(&self) -> usize {
-        self.secrets.a_L.len()
+    fn metrics(&self) -> Metrics {
+        Metrics {
+            multipliers: self.secrets.a_L.len(),
+            constraints: self.constraints.len() + self.deferred_constraints.len(),
+            phase_one_constraints: self.constraints.len(),
+            phase_two_constraints: self.deferred_constraints.len(),
+        }
     }
 
     fn constrain(&mut self, lc: LinearCombination) {
@@ -213,8 +219,8 @@ impl<'g, T: BorrowMut<Transcript>> ConstraintSystem for RandomizingProver<'g, T>
         self.prover.allocate_multiplier(input_assignments)
     }
 
-    fn multipliers_len(&self) -> usize {
-        self.prover.multipliers_len()
+    fn metrics(&self) -> Metrics {
+        self.prover.metrics()
     }
 
     fn constrain(&mut self, lc: LinearCombination) {

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -14,6 +14,7 @@ use super::{
 
 use crate::errors::R1CSError;
 use crate::generators::{BulletproofGens, PedersenGens};
+use crate::r1cs::Metrics;
 use crate::transcript::TranscriptProtocol;
 
 /// A [`ConstraintSystem`] implementation for use by the verifier.
@@ -117,8 +118,13 @@ impl<T: BorrowMut<Transcript>> ConstraintSystem for Verifier<T> {
         Ok((l_var, r_var, o_var))
     }
 
-    fn multipliers_len(&self) -> usize {
-        self.num_vars
+    fn metrics(&self) -> Metrics {
+        Metrics {
+            multipliers: self.num_vars,
+            constraints: self.constraints.len() + self.deferred_constraints.len(),
+            phase_one_constraints: self.constraints.len(),
+            phase_two_constraints: self.deferred_constraints.len(),
+        }
     }
 
     fn constrain(&mut self, lc: LinearCombination) {
@@ -165,8 +171,8 @@ impl<T: BorrowMut<Transcript>> ConstraintSystem for RandomizingVerifier<T> {
         self.verifier.allocate_multiplier(input_assignments)
     }
 
-    fn multipliers_len(&self) -> usize {
-        self.verifier.multipliers_len()
+    fn metrics(&self) -> Metrics {
+        self.verifier.metrics()
     }
 
     fn constrain(&mut self, lc: LinearCombination) {


### PR DESCRIPTION
Add methods to count the different kinds of constraints, which comes in handy when developing and benchmarking larger circuits. This is analogue with #284, `ConstraintSystem::multipliers_len()`.