### PR TITLE
Use a more verbose assert!() in r1cs docs example.

### DIFF
--- a/docs/r1cs-docs-example.md
+++ b/docs/r1cs-docs-example.md
@@ -547,10 +547,7 @@ let (proof, in_commitments, out_commitments) = {
 };
 
 let mut verifier_transcript = Transcript::new(b"ShuffleProofTest");
-assert!(
-    proof
-        .verify(&pc_gens, &bp_gens, &mut verifier_transcript, &in_commitments, &out_commitments)
-        .is_ok()
-);
+let verification_result = proof.verify(&pc_gens, &bp_gens, &mut verifier_transcript, &in_commitments, &out_commitments);
+assert!(verification_result.is_ok(), "{:?}", verification_result);
 # }
 ```


### PR DESCRIPTION
While debugging complex circuits, the actual R1CSError value does not become apparent while debugging. It might be difficult for newcomers to Bulletproofs to distinguish between the error condition of having written a faulty gadget (`proof.verify(...)` propagates `R1CSError`s through the `?` operator), versus not having allocated enough multipliers.

I am talking from experience here: I was looking at code, thinking my own gadget was failing, while in fact the assertion was copy-pasted from the example code in the docs!  Changing this, it became apparent that we needed to extend BulletproofGens a bit.