### PR TITLE
Set `Prover::eval` to pub, for easier debugging of circuits.

### DIFF
--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -354,6 +354,7 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
         (wL, wR, wO, wV)
     }
 
+    /// Returns the secret value of the linear combination.
     pub fn eval(&self, lc: &LinearCombination) -> Scalar {
         lc.terms
             .iter()

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -354,7 +354,7 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
         (wL, wR, wO, wV)
     }
 
-    fn eval(&self, lc: &LinearCombination) -> Scalar {
+    pub fn eval(&self, lc: &LinearCombination) -> Scalar {
         lc.terms
             .iter()
             .map(|(var, coeff)| {


### PR DESCRIPTION
Development of complex constraint systems often goes wrong, and this patch allows to evaluate (for the prover) the actual value of a LinearCombination.

Related to #278, if it doesn't even fix that.